### PR TITLE
Use hostname -f to get full machine name, including domain.

### DIFF
--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -132,7 +132,7 @@ verbose Checking out $PKG_NAME in tag $CMSSW_TAG.
 #fi
 
 if [ "X$CMSSW_GIT_REFERENCE" = X ]; then
-  case `hostname` in
+  case `hostname -f` in
     *.cern.ch)
       if [ -e /afs/cern.ch/cms/git-cmssw-mirror/cmssw.git ]; then
         CMSSW_GIT_REFERENCE=/afs/cern.ch/cms/git-cmssw-mirror/cmssw.git


### PR DESCRIPTION
Some machines at CERN do not return the domain part with a simple `hostname`
invokation. This forces them to return their full name, so that we can check
for the references also for their case. Reported by @cerati, requested also by @slava77.
