### PR TITLE
Handle the case in which some automatic merge left unhandled files around.

### DIFF
--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -81,10 +81,10 @@ git fetch https://github.com/$GITHUB_USER/cmssw.git +$BRANCH:$GITHUB_USER/$BRANC
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 # Attempt a merge in a separate branch
 git checkout merge-attempt >$DEBUG_STREAM
+git cms-sparse-checkout $CURRENT_BRANCH merge-attempt
 git merge --no-ff -m "Merged $BRANCH from repository $GITHUB_USER" $GITHUB_USER/$BRANCH || { echo "Unable to merge branch $BRANCH from repository $GITHUB_USER." ; exit 1; }
 git checkout $CURRENT_BRANCH 
 # Add the missing packages.
-git cms-sparse-checkout $CURRENT_BRANCH merge-attempt
 git read-tree -mu HEAD
 # This should always be a FF commit.
 git merge --ff merge-attempt >$DEBUG_STREAM 


### PR DESCRIPTION
Now we set up the sparse checkout early, at the beginning of the first merge,
so that all the operations happen with the correct configuration.
