### PR TITLE
re-implementation of git cms-init

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -11,7 +11,6 @@ usage () {
   $ECHO "-h                 \tthis help message"
   $ECHO
   $ECHO "-d, --debug        \tenable debug output"
-  $ECHO "-f, --force        \tforce dangerous operations"
   $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"
   $ECHO "    --ssh          \tuse ssh, rather than https to access the official repository"
   $ECHO "-z, --quiet        \tdo not print out progress"
@@ -20,7 +19,6 @@ usage () {
 }
 
 VERBOSE=1
-FORCE=0
 VERBOSE_STREAM=/dev/stderr
 DEBUG_STREAM=/dev/null
 
@@ -41,8 +39,6 @@ while [ "$#" != 0 ]; do
       shift; set +x; VERBOSE=0; VERBOSE_STREAM=/dev/null ;;
     -y | --yes )
       shift; ASSUME_YES=1 ;;
-    -f | --force )
-      shift; set +x; FORCE=1 ;;
     --https )
       shift; USE_HTTPS_ACCESS_METHOD=true ;;
     --ssh )


### PR DESCRIPTION
implement git cms-init to match the expected behaviour of git-cms-addpkg

for example, running git cms-init in an empty CMSSW_7_0_0_pre2 area will
- clone the official repository, using a local reference, inside $CMSSW_BASE/src and call it "official-cmssw"
- add the user's repository as my-cmssw, and read all branches and tags from it
- do not checkout any files, and set up sparse checkout using .gitignore as only entry (no need for FWCore/Version)
- create the local branch "CMSSW_7_0_X" to track "official-cmssw/CMSSW_7_0_X"
- create a new local branch "from-CMSSW_7_0_0_pre2" branching off at the commit corresponding to CMSSW_7_0_0_pre2

I've tested it with git 1.7.x (SLC6) and 1.8.x (SLC5 and CMSSW's), in releases that did and did not include a .gitignore file, and it seems to work in every case.

Supports the same options as git-cms-addpkg (--ssh, --http, etc.).
