### PR TITLE
implement addpkg -f FILE functionality

### DIFF
--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -139,7 +139,7 @@ if [ "$INPUT_FILE" ]; then
   verbose "`cat "$INPUT_FILE"`"
 
   # check the syntax of the input file
-  INVALID=`cat "$INPUT_FILE" | grep -v '^#' | grep -v '^\s*$' | grep -v -E '^/*\w+(/\w+)?/*$'`
+  INVALID=`cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | grep -v -E '^/*\w+(/\w+)?/*$'`
   if [ $? == 0 ]
     echo "Some lines of $INPUT_FILE are not in a valid format:"
     echo "$INVALID"
@@ -149,7 +149,7 @@ if [ "$INPUT_FILE" ]; then
 
   # add the requested package(s) to the sparse checkout
   cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
-  cat "$INPUT_FILE" | grep -v '^#' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
+  cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
   cat .git/info/sparse-checkout-new | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout
   rm -f .git/info/sparse-checkout-new
 else


### PR DESCRIPTION
This is on top of #37 and #38 .

Implement in git-cms-addpkg the functionality of "addpkg -f FILE" .

Note that FILE can contain any number of
- comments (lines starting with #)
- empty line (lines with only white spaces)
- subsystems (e.g. FWCore)
- packages (e.g. FWCore/Version)

Leading and trailing slashes are stripped, so these are valid, too:
- //FWCore/
- FWCore/Version///
- etc.
