### PR TITLE
fix syntax check for -f FILE, and move it before git-cms-init

### DIFF
--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -25,6 +25,9 @@ INITOPTIONS=""                      # options passed to git cms-init
 VERBOSE_STREAM=/dev/stderr
 DEBUG_STREAM=/dev/null
 
+RED='\033[31m'
+NORMAL='\033[0m'
+
 verbose () {
   if [ "X$VERBOSE" = X1 ]; then
     echo "$@"
@@ -91,6 +94,17 @@ if [ "$PKG_NAME" == "" ] && [ "$INPUT_FILE" == "" ] ; then
   echo "You need to specify at least one package or input file." ; exit 1
 fi
 
+if [ "$INPUT_FILE" ]; then
+  # check the syntax of the input file
+  INVALID=`cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | grep -v -E '^/*\w+(/\w+)?/*$' || true`
+  if [ -n "$INVALID" ]; then
+    $ECHO "Some lines of $INPUT_FILE are not in a valid format:"
+    $ECHO "$RED$INVALID$NORMAL"
+    exit 1
+  fi
+  unset INVALID
+fi
+
 # initialize the local repository
 git cms-init $INITOPTIONS
 cd $CMSSW_BASE/src
@@ -133,15 +147,6 @@ if [ "$INPUT_FILE" ]; then
   verbose "Checking out packages"
   verbose "`cat "$INPUT_FILE"`"
 
-  # check the syntax of the input file
-  INVALID=`cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | grep -v -E '^/*\w+(/\w+)?/*$'`
-  if [ $? == 0 ]; then
-    echo "Some lines of $INPUT_FILE are not in a valid format:"
-    echo "$INVALID"
-    exit 1
-  fi
-  unset INVALID
-
   # add the requested package(s) to the sparse checkout
   cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
   cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
@@ -163,7 +168,7 @@ CURRENT_BRANCH=`git symbolic-ref --short HEAD`
 if [ "$INPUT_FILE" ]; then
   for PKG_NAME in `cat $INPUT_FILE`; do
     if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
-      [ "$HEADER" ] || { echo "these packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
+      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
       echo $PKG_NAME
     fi
     [ "$HEADER" ] && exit 1


### PR DESCRIPTION
- fix: the check for the syntax of the input file specified with the -f option would silently _fail_ in case of a well-formatted file
- improvement: the check is done before setting up or updating the repository via git-cms-init
- improvement: add colours to the error message
