### PR TITLE
spare-checkout fixed to handle the file permission changes

### DIFF
--- a/git-cms-sparse-checkout
+++ b/git-cms-sparse-checkout
@@ -92,6 +92,9 @@ cp -f $INFO_DIR/sparse-checkout $INFO_DIR/sparse-checkout-new
 for x in `git diff $REGEX_OPT $REGEX $REF1..$REF2 --name-only | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
   echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
+for x in `git diff $REF1..$REF2 | grep '^old mode' -C 1 | grep '^diff --git' | sed -e 's|.* ||;s|b/||' | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
+  echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
+done
 
 cat $INFO_DIR/sparse-checkout-new | sort -u > $INFO_DIR/sparse-checkout
 rm -f $INFO_DIR/sparse-checkout-new


### PR DESCRIPTION
As -G does not catch the file mode changes so for file permission changes we run git diff again without -G
