### PR TITLE
git-cms-init: move the HTTPS check before the creation of a peronal reference repository

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -192,11 +192,9 @@ fi
 if [ "$PROTOCOL" = "ssh" ]; then
   OFFICIAL_CMSSW_REPO=git@github.com:cms-sw/cmssw.git
   USER_CMSSW_REPO=git@github.com:$GITHUB_USERNAME/cmssw.git
-  USER_CMSSW_REPO_PUSH=git@github.com:$GITHUB_USERNAME/cmssw.git
 elif [ "$PROTOCOL" = "https" ]; then
   OFFICIAL_CMSSW_REPO=https://github.com/cms-sw/cmssw.git
   USER_CMSSW_REPO=https://github.com/$GITHUB_USERNAME/cmssw.git
-  USER_CMSSW_REPO_PUSH=https://github.com/$GITHUB_USERNAME/cmssw.git
 elif [ "$PROTOCOL" = "mixed" ]; then
   OFFICIAL_CMSSW_REPO=https://github.com/cms-sw/cmssw.git
   USER_CMSSW_REPO=https://github.com/$GITHUB_USERNAME/cmssw.git
@@ -207,7 +205,7 @@ fi
 if git config remote.my-cmssw.url >& /dev/null; then
   CUSTOM_REMOTE=true
   USER_CMSSW_REPO=`git config remote.my-cmssw.url`
-  USER_CMSSW_REPO_PUSH="$USER_CMSSW_REPO"
+  USER_CMSSW_REPO_PUSH=`git config remote.my-cmssw.pushurl`
   $ECHO "Attention: using the 'my-cmssw' remote from your git configuration: $RED$USER_CMSSW_REPO$NORMAL"     > $VERBOSE_STREAM
 fi
 
@@ -347,7 +345,7 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
     if ! [ "$CUSTOM_REMOTE" ]; then
       # add the user's remote repository
       git remote add my-cmssw $USER_CMSSW_REPO
-      git remote set-url --push my-cmssw $USER_CMSSW_REPO_PUSH
+      [ "$USER_CMSSW_REPO_PUSH" ] && git remote set-url --push my-cmssw $USER_CMSSW_REPO_PUSH
     fi
     git fetch my-cmssw --tags       2> $VERBOSE_STREAM
   fi


### PR DESCRIPTION
this should fix the case where access via HTTPS is not available, and the user has not yet created a personal reference repository using SSH
