### PR TITLE
exit with zero code if input file is provided and all packages are properly checked out

### DIFF
--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -169,11 +169,12 @@ if [ "$INPUT_FILE" ]; then
       [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
       echo $PKG_NAME
     fi
-    [ "$HEADER" ] && exit 1
   done
+  [ "$HEADER" ] && exit 1
 else
   if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
     echo "package $PKG_NAME does not exist in branch $CURRENT_BRANCH"
     exit 1
   fi
 fi
+exit 0


### PR DESCRIPTION
When -f <input> file is provided then git-cms-addpkg always exit with exit code 1
 - first we should check for $HEADER only after looping over all packages
 - need to explicitly exit with 0 at the end otherwise script exit with exit code of last command which in case of every think OK is   [ "$HEADER" ] 

