### PR TITLE
add trailing slash only if one is already available for sparse-checkout 

### DIFF
--- a/git-cms-sparse-checkout
+++ b/git-cms-sparse-checkout
@@ -93,7 +93,7 @@ for x in `git diff $REGEX_OPT $REGEX $REF1..$REF2 --name-only | grep -v ".gitcon
   echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
 for x in `git diff $REF1..$REF2 | grep '^old mode' -C 1 | grep '^diff --git' | sed -e 's|.* ||;s|b/||' | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
-  echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
+  echo "$x" | sed -e "/\//s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
 
 cat $INFO_DIR/sparse-checkout-new | sort -u > $INFO_DIR/sparse-checkout

--- a/git-cms-sparse-checkout
+++ b/git-cms-sparse-checkout
@@ -93,7 +93,7 @@ for x in `git diff $REGEX_OPT $REGEX $REF1..$REF2 --name-only | grep -v ".gitcon
   echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
 for x in `git diff $REF1..$REF2 | grep '^old mode' -C 1 | grep '^diff --git' | sed -e 's|.* ||;s|b/||' | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
-  echo "$x" | sed -e "/\//s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
+  echo "$x" | sed -e "s|[/][/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
 
 cat $INFO_DIR/sparse-checkout-new | sort -u > $INFO_DIR/sparse-checkout


### PR DESCRIPTION
current version kills possibility to merge-topic changes with non-package structure.
A specific example is when using submodules .gitmodules file and the submodule reference do not make it properly to the local copy.

the sed preselection will add the trailing slash for CMSSW packages (all have a form of sub/pack),
but not for other elements (files or submodule references and such)