### PR TITLE
Add cms-checkout-topic tool

### DIFF
--- a/docs/man/git-cms-checkout-topic.1.in
+++ b/docs/man/git-cms-checkout-topic.1.in
@@ -1,16 +1,16 @@
-.TH GIT_CMS_MERGE_TOPIC 1 LOCAL
+.TH GIT_CMS_CHECKOUT_TOPIC 1 LOCAL
 
 .SH NAME
 
-git-cms-merge-topic - CMSSW helper to merge a given branch or pull request into your workarea.
+git-cms-checkout-topic - CMSSW helper to checkout a given branch or pull request into your workarea (without merging).
 
 .SH SYNOPSIS
 
-.B git cms-merge-topic <pull-request-id>
+.B git cms-checkout-topic <pull-request-id>
 
-.B git cms-merge-topic <official-cmssw-branch>
+.B git cms-checkout-topic <official-cmssw-branch>
 
-.B git cms-merge-topic <github-user>:<branch>
+.B git cms-checkout-topic <github-user>:<branch>
 
 .SH OPTIONS
 
@@ -34,31 +34,16 @@ Access GitHub over ssh.
 
 .TP 5
 
---no-commit
-
-Do not do the final commit when merging.
-
-.TP 5
-
--s, --strategy
-
-Specify strategy when merging (see git merge documentation).
-
-.TP 5
-
--X, --strategy-option
-
-Specify strategy option when merging (see git merge documentation).
-
-.TP 5
-
 -u, --unsafe
 
 Do not perform checkdeps at the end of the checkout.
 
 .SH DESCRIPTION
 
-This is the git equivalent of the old CVS cmstc tagset <tagset-id> command.
+This is an alternate mode for git-cms-merge-topic.
+It is useful to recreate a working area or rebase a branch,
+by checking out only the packages modified
+in the specified branch (and their dependencies) without performing a merge.
 There are three different syntaxes, depending on whether you want to merge a pull
 request (specified via its numeric id, <pull-request-id>), a generic branch in
 the official-cmssw (https://github.com/cms-sw/cmssw) repository, or a branch in

--- a/git-cms-checkout-topic
+++ b/git-cms-checkout-topic
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 
-git cms-merge-topic -n "$@"
+# cms-merge-topic checks if it was called by this wrapper
+git-cms-merge-topic "$@"
 

--- a/git-cms-checkout-topic
+++ b/git-cms-checkout-topic
@@ -1,5 +1,1 @@
-#!/bin/bash -e
-
-# cms-merge-topic checks if it was called by this wrapper
-git-cms-merge-topic "$@"
-
+git-cms-merge-topic

--- a/git-cms-checkout-topic
+++ b/git-cms-checkout-topic
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+git cms-merge-topic -n "$@"
+

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -18,6 +18,7 @@ usage() {
   $ECHO "-s, --strategy     \tspecify strategy when merging"
   $ECHO "-X, --strategy-option     \tspecify strategy when merging"
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
+  $ECHO "-n, --no-merge       \tdo not perform a merge, just checkout code from specified branch"
   exit 1
 }
 
@@ -32,6 +33,10 @@ while [ $# -gt 0 ]; do
   case $1 in 
     -u|--unsafe)
       UNSAFE=true
+      shift
+      ;;
+    -n|--no-merge)
+      NOMERGE=true
       shift
       ;;
     -d|--debug)
@@ -71,12 +76,15 @@ while [ $# -gt 0 ]; do
       # - Pull request: `<pull-request-id>`
       GITHUB_USER=cms-sw ; 
       BRANCH=$1 ;
+      LOCAL_BRANCH=$1 ;
       case $1 in
         *:*)
           BRANCH=`echo $1 | cut -f2 -d:`
+          LOCAL_BRANCH=$BRANCH
           GITHUB_USER=`echo $1 | cut -f1 -d:` ;;
         [0-9]*) 
-          BRANCH=refs/pull/$1/head ;; 
+          BRANCH=refs/pull/$1/head 
+          LOCAL_BRANCH=PR$1 ;; 
       esac ;
       shift
     ;;
@@ -118,6 +126,11 @@ fi
 
 PULL_ID=$1
 
+TEMP_BRANCH=merge-attempt
+if [ "X$NOMERGE" = Xtrue ]; then
+  TEMP_BRANCH=checkout-attempt
+fi
+
 # initialize the local repository
 if [ -z "$CMSSW_BASE" ]; then
   echo "CMSSW environment not setup, please run 'cmsenv' before 'git cms-merge-topic'."
@@ -128,7 +141,7 @@ if ! [ -d $CMSSW_BASE/src/.git ]; then
 fi
 
 cd $CMSSW_BASE/src
-git fetch . +HEAD:merge-attempt || { echo "You are on a failed merge branch. Do \"git branch\" and checkout the one you were on."; exit 1; }
+git fetch . +HEAD:$TEMP_BRANCH || { echo "You are on a failed merge branch. Do \"git branch\" and checkout the one you were on."; exit 1; }
 
 if [ "$(git status --porcelain --untracked=no | grep '^[ACDMRU]')" ]; then
   $ECHO "${RED}Error:${NORMAL} there are staged but not committed changes on your working tree, please commit or stash them."
@@ -148,26 +161,33 @@ if [ -z "$COMMIT" ]; then
 fi
 
 # Fetch the branch specified from github and replace merge-attempt with it. 
-# The + is used to force the merge-attampt branch to be updated.
+# The + is used to force the merge-attempt branch to be updated.
 git fetch -n $REPOSITORY +$COMMIT:$GITHUB_USER/$BRANCH
 # Save the name of the current branch.
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 # Attempt a merge in a separate branch
-git checkout merge-attempt >&${debug}
+git checkout $TEMP_BRANCH >&${debug}
 MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $CURRENT_BRANCH`
 git cms-sparse-checkout $DEBUG_OPT $MERGE_BASE $GITHUB_USER/$BRANCH
 git read-tree -mu HEAD
-git merge $NO_COMMIT $MERGE_STRATEGY $STRATEGY_OPTION --no-ff -m "Merged $BRANCH from repository $GITHUB_USER" $GITHUB_USER/$BRANCH || { echo "Unable to merge branch $BRANCH from repository $GITHUB_USER." ; exit 1; }
-if [ ! X$NO_COMMIT = X ]; then
-  echo \"--no-commit\" specified: not committing and leaving you on the merge-attempt branch.\n Use git-status to check changes. ; exit 0
+# in no-merge case, just checkout a new branch
+if [ "X$NOMERGE" = Xtrue ]; then
+  git checkout -b $LOCAL_BRANCH $GITHUB_USER/$BRANCH
+  echo "Created branch $LOCAL_BRANCH to follow $BRANCH from repository $GITHUB_USER"
+# otherwise, perform merge
+else
+  git merge $NO_COMMIT $MERGE_STRATEGY $STRATEGY_OPTION --no-ff -m "Merged $BRANCH from repository $GITHUB_USER" $GITHUB_USER/$BRANCH || { echo "Unable to merge branch $BRANCH from repository $GITHUB_USER." ; exit 1; }
+  if [ ! X$NO_COMMIT = X ]; then
+    echo \"--no-commit\" specified: not committing and leaving you on the $TEMP_BRANCH branch.\n Use git-status to check changes. ; exit 0
+  fi
+  git checkout $CURRENT_BRANCH 
+  # Add the missing files.
+  git read-tree -mu HEAD
+  # This should always be a FF commit.
+  git merge --ff $TEMP_BRANCH >&${debug}
 fi
-git checkout $CURRENT_BRANCH 
-# Add the missing files.
-git read-tree -mu HEAD
-# This should always be a FF commit.
-git merge --ff merge-attempt >&${debug}
 # Delete the branch used for merge
-git branch -D merge-attempt >&${debug} || true
+git branch -D $TEMP_BRANCH >&${debug} || true
 # Do checkdeps unless not specified.
 if [ ! "X$UNSAFE" = Xtrue ]; then
   git cms-checkdeps -a

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -32,10 +32,7 @@ DEBUG=0
 PROTOCOL=https
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
-PARENT_NAME=$(echo "$(ps -o comm= $PPID)")
-# ps command names get truncated
-if [ "$PARENT_NAME" = "git-cms-checkou" ]; then
-  COMMAND_NAME=cms-checkout-topic
+if [ "$COMMAND_NAME" = "cms-checkout-topic" ]; then
   NOMERGE=true
 fi
 

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -7,6 +7,7 @@ esac
 
 usage() {
   COMMAND_NAME=$1
+  CODE=$2
   $ECHO "git $COMMAND_NAME [options] <github-user>:<branch>"
   $ECHO "git $COMMAND_NAME [options] <official-cmssw-branch>"
   $ECHO "git $COMMAND_NAME [options] <pull-request-id>"
@@ -18,10 +19,10 @@ usage() {
   if [ "$COMMAND_NAME" = "cms-merge-topic" ]; then
     $ECHO "    --no-commit    \tdo not do the final commit when merging"
     $ECHO "-s, --strategy     \tspecify strategy when merging"
-    $ECHO "-X, --strategy-option     \tspecify strategy when merging"
+    $ECHO "-X, --strategy-option     \tspecify strategy option when merging"
   fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
-  exit 1
+  exit $CODE
 }
 
 # colors and formatting
@@ -66,6 +67,8 @@ while [ $# -gt 0 ]; do
       STRATEGY_OPTION="-X $2"
       shift; shift
       ;;
+    -h|--help)
+      usage $COMMAND_NAME 0;;
     -*)
       echo "Unknown option $1" ; exit 1 ;;
     *)
@@ -94,7 +97,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 if [ "$BRANCH" == "" ]; then
-  usage $COMMAND_NAME
+  usage $COMMAND_NAME 1
 fi
 
 BASH_FULL_VERSION=$((${BASH_VERSINFO[0]} * 10000 + ${BASH_VERSINFO[1]} * 100 + ${BASH_VERSINFO[2]}))

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -32,16 +32,17 @@ DEBUG=0
 PROTOCOL=https
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
+PARENT_NAME=$(echo "$(ps -o comm= $PPID)")
+# ps command names get truncated
+if [ "$PARENT_NAME" = "git-cms-checkou" ]; then
+  COMMAND_NAME=cms-checkout-topic
+  NOMERGE=true
+fi
 
 while [ $# -gt 0 ]; do
   case $1 in 
     -u|--unsafe)
       UNSAFE=true
-      shift
-      ;;
-    -n|--no-merge)
-      NOMERGE=true
-      COMMAND_NAME=cms-checkout-topic
       shift
       ;;
     -d|--debug)

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -13,6 +13,8 @@ usage() {
   $ECHO "git $COMMAND_NAME [options] <pull-request-id>"
   $ECHO
   $ECHO "Options:"
+  $ECHO "-h, --help         \tthis help message"
+  $ECHO
   $ECHO "-d, --debug        \tenable debug output"
   $ECHO "    --https        \taccess GitHub over https (default)"
   $ECHO "    --ssh          \taccess GitHub over ssh"

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -31,7 +31,7 @@ NORMAL='\033[0m'
 DEBUG=0
 PROTOCOL=https
 
-COMMAND_NAME=cms-merge-topic
+COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
 
 while [ $# -gt 0 ]; do
   case $1 in 
@@ -89,7 +89,7 @@ while [ $# -gt 0 ]; do
           GITHUB_USER=`echo $1 | cut -f1 -d:` ;;
         [0-9]*) 
           BRANCH=refs/pull/$1/head 
-          LOCAL_BRANCH=PR$1 ;; 
+          LOCAL_BRANCH=pull/$1 ;; 
       esac ;
       shift
     ;;
@@ -131,10 +131,11 @@ fi
 
 PULL_ID=$1
 
-TEMP_BRANCH=merge-attempt
+TEMP_BRANCH_WORD=merge
 if [ "X$NOMERGE" = Xtrue ]; then
-  TEMP_BRANCH=checkout-attempt
+  TEMP_BRANCH_WORD=checkout
 fi
+TEMP_BRANCH=${TEMP_BRANCH_WORD}-attempt
 
 # initialize the local repository
 if [ -z "$CMSSW_BASE" ]; then
@@ -146,7 +147,7 @@ if ! [ -d $CMSSW_BASE/src/.git ]; then
 fi
 
 cd $CMSSW_BASE/src
-git fetch . +HEAD:$TEMP_BRANCH || { echo "You are on a failed merge branch. Do \"git branch\" and checkout the one you were on."; exit 1; }
+git fetch . +HEAD:$TEMP_BRANCH || { echo "You are on a failed $TEMP_BRANCH_WORD branch. Do \"git branch\" and checkout the one you were on."; exit 1; }
 
 if [ "$(git status --porcelain --untracked=no | grep '^[ACDMRU]')" ]; then
   $ECHO "${RED}Error:${NORMAL} there are staged but not committed changes on your working tree, please commit or stash them."
@@ -176,7 +177,7 @@ MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $CURRENT_BRANCH`
 git cms-sparse-checkout $DEBUG_OPT $MERGE_BASE $GITHUB_USER/$BRANCH
 git read-tree -mu HEAD
 # in no-merge case, just checkout a new branch
-if [ "X$NOMERGE" = Xtrue ]; then
+if [ "$NOMERGE" = "true" ]; then
   git checkout -b $LOCAL_BRANCH $GITHUB_USER/$BRANCH
   echo "Created branch $LOCAL_BRANCH to follow $BRANCH from repository $GITHUB_USER"
 # otherwise, perform merge

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -6,19 +6,21 @@ case `uname` in
 esac
 
 usage() {
-  $ECHO "git cms-merge-topic [options] <github-user>:<branch>"
-  $ECHO "git cms-merge-topic [options] <official-cmssw-branch>"
-  $ECHO "git cms-merge-topic [options] <pull-request-id>"
+  COMMAND_NAME=$1
+  $ECHO "git $COMMAND_NAME [options] <github-user>:<branch>"
+  $ECHO "git $COMMAND_NAME [options] <official-cmssw-branch>"
+  $ECHO "git $COMMAND_NAME [options] <pull-request-id>"
   $ECHO
   $ECHO "Options:"
   $ECHO "-d, --debug        \tenable debug output"
   $ECHO "    --https        \taccess GitHub over https (default)"
   $ECHO "    --ssh          \taccess GitHub over ssh"
-  $ECHO "    --no-commit    \tdo not do the final commit when merging"
-  $ECHO "-s, --strategy     \tspecify strategy when merging"
-  $ECHO "-X, --strategy-option     \tspecify strategy when merging"
+  if [ "$COMMAND_NAME" = "cms-merge-topic" ]; then
+    $ECHO "    --no-commit    \tdo not do the final commit when merging"
+    $ECHO "-s, --strategy     \tspecify strategy when merging"
+    $ECHO "-X, --strategy-option     \tspecify strategy when merging"
+  fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
-  $ECHO "-n, --no-merge       \tdo not perform a merge, just checkout code from specified branch"
   exit 1
 }
 
@@ -29,6 +31,8 @@ NORMAL='\033[0m'
 DEBUG=0
 PROTOCOL=https
 
+COMMAND_NAME=cms-merge-topic
+
 while [ $# -gt 0 ]; do
   case $1 in 
     -u|--unsafe)
@@ -37,6 +41,7 @@ while [ $# -gt 0 ]; do
       ;;
     -n|--no-merge)
       NOMERGE=true
+      COMMAND_NAME=cms-checkout-topic
       shift
       ;;
     -d|--debug)
@@ -91,7 +96,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 if [ "$BRANCH" == "" ]; then
-  usage
+  usage $COMMAND_NAME
 fi
 
 BASH_FULL_VERSION=$((${BASH_VERSINFO[0]} * 10000 + ${BASH_VERSINFO[1]} * 100 + ${BASH_VERSINFO[2]}))


### PR DESCRIPTION
This adds `cms-checkout-topic` as a wrapper for a new `--no-merge` option in `cms-merge-topic`. This option is primarily intended to help with rebasing PRs, by allowing users to set up the modified packages and source code for a topic branch in a release area *without* doing a merge (which can cause 100s of duplicate commits).

Most of the functionality is duplicated from `cms-merge-topic`, so the new option is added there rather than making an entirely separate script. The `cms-checkout-topic` wrapper is added to have a more self-explanatory description of the command (however git-esque `cms-merge-topic --no-merge` might be...).