### PR TITLE
add cms-rmpkg tool

### DIFF
--- a/docs/man/git-cms-addpkg.1.in
+++ b/docs/man/git-cms-addpkg.1.in
@@ -2,35 +2,40 @@
 
 .SH NAME
 
-git-cms-addpkg - CMSSW helper to checkout single packages from the git repository.
+git-cms-addpkg - CMSSW helper to checkout single packages from the git repository in the working area.
 
 .SH SYNOPSIS
 
-.B git cms-addpkg [options] <package> [<tag>]
+.B git cms-addpkg [options] <subsystem/package> [<subsystem/package> ...] 
+
+.B git cms-addpkg [options] -f FILE
 
 .SH DESCRIPTION
 
-This is the git equivalent of the old CVS addpkg commant. <package> is the
-package you want to checkout (e.g. FWCore/Version), <tag> is the optional
-release tag which you want to checkout. By default it will use the tag used for
-the current release area.
+This is the git equivalent of the old CVS addpkg command. <package> is the
+package you want to checkout (e.g. FWCore/Version), or <subsystem> is the
+subsystem you want to checkout (e.g. FWCore).
+If the local repository has not been initialized, it will call git-cms-init.
 
 .SH OPTIONS
-
-The defaults should be just fine, however you can fine tune output of the
-command with the following options.
 
 .TP 5
 
 -d, --debug        
 
-enable debug output"
+enable debug output
 
 .TP 5
 
--f, --force
+-f, --file FILE
 
-force dangerous operations
+read the list of packages to be checked out from FILE
+
+.TP 5  
+
+-q, --quiet, -z
+
+do not print out progress
 
 .TP 5
 
@@ -38,11 +43,11 @@ force dangerous operations
 
 use https, rather than ssh to access your personal repository
 
-.TP 5  
+.TP 5
 
--q, --quiet
+--ssh
 
-do not print out progress
+use ssh, rather than https to access the official repository
 
 .TP 5
 

--- a/docs/man/git-cms-rmpkg.1.in
+++ b/docs/man/git-cms-rmpkg.1.in
@@ -1,0 +1,39 @@
+.TH GIT_CMS_RMPKG 1 LOCAL
+
+.SH NAME
+
+git-cms-rmpkg - CMSSW helper to remove (un-checkout) single packages or subsystems from the git repository in the working area.
+
+.SH SYNOPSIS
+
+.B git cms-rmpkg [options] <subsystem/package> [<subsystem/package> ...] 
+
+.B git cms-rmpkg [options] -f FILE
+
+.SH DESCRIPTION
+
+This command can undo the actions of the git-cms-addpkg command,
+removing <package> (e.g. FWCore/Version) or <subsystem> (e.g. FWCore)
+from your working area (but NOT from the repository itself).
+This is useful if you decide you do not want to recompile the package/subsystem,
+but instead to use the precompiled library for the release.
+
+.SH OPTIONS
+
+.TP 5
+
+-d, --debug        
+
+enable debug output
+
+.TP 5
+
+-f, --file FILE
+
+read the list of packages to be checked out from FILE
+
+.TP 5  
+
+-q, --quiet, -z
+
+do not print out progress

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -14,10 +14,10 @@ usage () {
   $ECHO "git $COMMAND_NAME [options] -f FILE"
   $ECHO
   $ECHO "Options:"
-  $ECHO "-h                 \tthis help message"
+  $ECHO "-h, --help         \tthis help message"
   $ECHO
   $ECHO "-d, --debug        \tenable debug output"
-  $ECHO "-f, --file FILE    \tread the list of packages to be checkoed out from FILE"
+  $ECHO "-f, --file FILE    \tread the list of packages to be checked out from FILE"
   $ECHO "-q, --quiet, -z    \tdo not print out progress"
   if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
     $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -9,20 +9,58 @@ case `uname` in
 esac
 
 usage () {
-  $ECHO "git cms-addpkg [options] Subsystem/Package [Subsystem/Package ...] "
-  $ECHO "git cms-addpkg [options] -f FILE"
+  COMMAND_NAME=$1
+  $ECHO "git $COMMAND_NAME [options] Subsystem/Package [Subsystem/Package ...] "
+  $ECHO "git $COMMAND_NAME [options] -f FILE"
   $ECHO
   $ECHO "Options:"
   $ECHO "-h                 \tthis help message"
   $ECHO
   $ECHO "-d, --debug        \tenable debug output"
   $ECHO "-f, --file FILE    \tread the list of packages to be checkoed out from FILE"
-  $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"
-  $ECHO "    --ssh          \tuse ssh, rather than https to access the official repository"
   $ECHO "-q, --quiet, -z    \tdo not print out progress"
-  $ECHO "-y, --yes          \tassume yes to all questions"
-  exit $1
+  if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
+    $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"
+    $ECHO "    --ssh          \tuse ssh, rather than https to access the official repository"
+    $ECHO "-y, --yes          \tassume yes to all questions"
+  fi
+  exit $2
 }
+
+checkPkgFile () {
+  INPUT_FILE="$1"
+  CURRENT_BRANCH="$2"
+  for PKG_NAME in `cat $INPUT_FILE`; do
+    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
+      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
+      echo $PKG_NAME
+    fi
+  done
+  if [ "$HEADER" ]; then
+    exit 1
+  fi
+}
+
+checkPkgList () {
+  PACKAGES="$1"
+  CURRENT_BRANCH="$2"
+  for PKG_NAME in $PACKAGES; do
+    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
+      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
+      echo $PKG_NAME
+    fi
+  done
+  if [ "$HEADER" ]; then
+    exit 1
+  fi
+}
+
+COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
+ACTION="Checking out"
+if [ "$COMMAND_NAME" = "cms-rmpkg" ]; then
+  RMPKG=true
+  ACTION="Removing"
+fi
 
 DEBUG=0
 VERBOSE=1
@@ -43,7 +81,7 @@ verbose () {
 while [ "$#" != 0 ]; do
   case "$1" in
     -h | --help )
-      usage 0;;
+      usage $COMMAND_NAME 0;;
     -d | --debug )
       INITOPTIONS="$INITOPTIONS $1"
       shift; set -x; DEBUG=1 ;;
@@ -57,7 +95,7 @@ while [ "$#" != 0 ]; do
       elif [ ! -r "$INPUT_FILE" ]; then
         $ECHO "git cms-addpkg: file $INPUT_FILE does not exist or is not readable"
         $ECHO
-        usage 1
+        usage $COMMAND_NAME 1
       fi
       unset OPTION
       ;;
@@ -74,7 +112,7 @@ while [ "$#" != 0 ]; do
       INITOPTIONS="$INITOPTIONS $1"
       shift;;
     -*)
-      $ECHO "git cms-addpkg: unknown option $1"; $ECHO; usage 1;;
+      $ECHO "git cms-addpkg: unknown option $1"; $ECHO; usage $COMMAND_NAME 1;;
     *)
       if [ "$INPUT_FILE" == "" ]; then
         # check out a list of packages
@@ -82,17 +120,17 @@ while [ "$#" != 0 ]; do
         shift
       else
         # check out a list of packages via -f / --file FILE
-        $ECHO "git cms-addpkg: you cannot specify a package and input from file at the same time."
+        $ECHO "git $COMMAND_NAME: you cannot specify a package and input from file at the same time."
         $ECHO
-        usage 1
+        usage $COMMAND_NAME 1
       fi
     ;;
   esac
 done
 if [ "$PACKAGES" == "" ] && [ "$INPUT_FILE" == "" ] ; then
-  $ECHO "git cms-addpkg: you need to specify at least one package or input file."
+  $ECHO "git $COMMAND_NAME: you need to specify at least one package or input file."
   $ECHO
-  usage 1
+  usage $COMMAND_NAME 1
 fi
 
 BASH_FULL_VERSION=$((${BASH_VERSINFO[0]} * 10000 + ${BASH_VERSINFO[1]} * 100 + ${BASH_VERSINFO[2]}))
@@ -145,11 +183,16 @@ fi
 
 # initialize the local repository
 if [ -z "$CMSSW_BASE" ]; then
-  $ECHO "CMSSW environment not setup, please run 'cmsenv' before 'git cms-addpkg'."
+  $ECHO "CMSSW environment not setup, please run 'cmsenv' before 'git $COMMAND_NAME'."
   exit 1
 fi
 if ! [ -d $CMSSW_BASE/src/.git ]; then
-  git cms-init $INITOPTIONS
+  if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
+    $ECHO "git $COMMAND_NAME : nothing to do."
+    exit 1
+  else
+    git cms-init $INITOPTIONS
+  fi
 fi
 
 cd $CMSSW_BASE/src
@@ -166,7 +209,7 @@ esac
 
 # check if using a reference repository
 if [ "$CMSSW_GIT_REFERENCE" == "" ] && [ -f $CMSSW_BASE/src/.git/objects/info/alternates ]; then
-  CMSSW_GIT_REFERENCE=`cat .git/objects/info/alternates | head -n1`
+  CMSSW_GIT_REFERENCE=`cat $CMSSW_BASE/src/.git/objects/info/alternates | head -n1`
 fi
 
 # if using a personal reference repository, update it from the official one
@@ -179,48 +222,62 @@ if [ "$(git status --porcelain --untracked=no | grep '^[ACDMRU]')" ]; then
   exit 1
 fi
 
+CURRENT_BRANCH=`git symbolic-ref --short HEAD`
+
+# check if requested packages are present to be removed
+if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
+  CHECK_RETURN=0
+  if [ "$INPUT_FILE" ]; then
+    checkPkgFile "$INPUT_FILE" "$CURRENT_BRANCH"
+  else
+    checkPkgList "$PACKAGES" "$CURRENT_BRANCH"
+  fi
+fi
+
+# create temporary sparse checkout file
+if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
+  cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
+else
+  touch $CMSSW_BASE/src/.git/info/sparse-checkout-new
+fi
+
+# add the requested package(s) to the temporary file
 if [ "$INPUT_FILE" ]; then
-  verbose "Checking out packages"
+  verbose "$ACTION packages"
   verbose "`cat "$INPUT_FILE"`"
 
-  # add the requested package(s) to the sparse checkout
-  cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
   cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
-  cat .git/info/sparse-checkout-new | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout
-  rm -f .git/info/sparse-checkout-new
 else
-  verbose "Checking out packages"
+  verbose "$ACTION packages"
   for PKG_NAME in $PACKAGES; do
     verbose $PKG_NAME
   done
 
-  # add the requested package(s) to the sparse checkout
-  cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
   for PKG_NAME in $PACKAGES; do
     echo $PKG_NAME | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
   done
-  cat .git/info/sparse-checkout-new | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout
-  rm -f .git/info/sparse-checkout-new
 fi
 
-git read-tree -mu HEAD
-CURRENT_BRANCH=`git symbolic-ref --short HEAD`
-
-if [ "$INPUT_FILE" ]; then
-  for PKG_NAME in `cat $INPUT_FILE`; do
-    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
-      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
-      echo $PKG_NAME
-    fi
-  done
-  [ "$HEADER" ] && exit 1
+# add or remove from the real sparse checkout file
+cat $CMSSW_BASE/src/.git/info/sparse-checkout-new | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted
+if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
+  mv $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted $CMSSW_BASE/src/.git/info/sparse-checkout
+  rm -f $CMSSW_BASE/src/.git/info/sparse-checkout-new
 else
-  for PKG_NAME in $PACKAGES; do
-    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
-      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
-      echo $PKG_NAME
-    fi
-  done
-  [ "$HEADER" ] && exit 1
+  grep -v -x -f $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted $CMSSW_BASE/src/.git/info/sparse-checkout > $CMSSW_BASE/src/.git/info/sparse-checkout-new
+  mv $CMSSW_BASE/src/.git/info/sparse-checkout-new $CMSSW_BASE/src/.git/info/sparse-checkout
+  rm -f $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted
 fi
-exit 0
+
+# update the working area
+git read-tree -mu HEAD
+
+# check if requested packages were successfully added
+if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
+  if [ "$INPUT_FILE" ]; then
+    checkPkgFile "$INPUT_FILE" "$CURRENT_BRANCH"
+  else
+    checkPkgList "$PACKAGES" "$CURRENT_BRANCH"
+  fi
+  exit 0
+fi

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -226,7 +226,6 @@ CURRENT_BRANCH=`git symbolic-ref --short HEAD`
 
 # check if requested packages are present to be removed
 if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
-  CHECK_RETURN=0
   if [ "$INPUT_FILE" ]; then
     checkPkgFile "$INPUT_FILE" "$CURRENT_BRANCH"
   else
@@ -235,18 +234,14 @@ if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
 fi
 
 # create temporary sparse checkout file
-if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
-  cp -f $CMSSW_BASE/src/.git/info/sparse-checkout $CMSSW_BASE/src/.git/info/sparse-checkout-new
-else
-  touch $CMSSW_BASE/src/.git/info/sparse-checkout-new
-fi
+touch $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
 
 # add the requested package(s) to the temporary file
 if [ "$INPUT_FILE" ]; then
   verbose "$ACTION packages"
   verbose "`cat "$INPUT_FILE"`"
 
-  cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
+  cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
 else
   verbose "$ACTION packages"
   for PKG_NAME in $PACKAGES; do
@@ -254,20 +249,41 @@ else
   done
 
   for PKG_NAME in $PACKAGES; do
-    echo $PKG_NAME | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
+    echo $PKG_NAME | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
   done
 fi
 
 # add or remove from the real sparse checkout file
-cat $CMSSW_BASE/src/.git/info/sparse-checkout-new | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted
 if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
-  mv $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted $CMSSW_BASE/src/.git/info/sparse-checkout
-  rm -f $CMSSW_BASE/src/.git/info/sparse-checkout-new
+  cat $CMSSW_BASE/src/.git/info/sparse-checkout-tmp | while read LINE; do
+    # remove any exclusion line(s)
+    grep -v "^\!$LINE" $CMSSW_BASE/src/.git/info/sparse-checkout > $CMSSW_BASE/src/.git/info/sparse-checkout-new
+    mv $CMSSW_BASE/src/.git/info/sparse-checkout-new $CMSSW_BASE/src/.git/info/sparse-checkout
+    # if addition line not present, append it
+    if ! grep -q -x "$LINE" $CMSSW_BASE/src/.git/info/sparse-checkout; then
+      echo "$LINE" >> $CMSSW_BASE/src/.git/info/sparse-checkout
+    fi
+  done
 else
-  grep -v -x -f $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted $CMSSW_BASE/src/.git/info/sparse-checkout > $CMSSW_BASE/src/.git/info/sparse-checkout-new
-  mv $CMSSW_BASE/src/.git/info/sparse-checkout-new $CMSSW_BASE/src/.git/info/sparse-checkout
-  rm -f $CMSSW_BASE/src/.git/info/sparse-checkout-new-sorted
+  cat $CMSSW_BASE/src/.git/info/sparse-checkout-tmp | while read LINE; do
+    # remove any addition line(s)
+    grep -v "^$LINE" $CMSSW_BASE/src/.git/info/sparse-checkout > $CMSSW_BASE/src/.git/info/sparse-checkout-new
+    mv $CMSSW_BASE/src/.git/info/sparse-checkout-new $CMSSW_BASE/src/.git/info/sparse-checkout
+    # special case: append exclusion line for package (if whole subsystem previously added)
+    if echo $LINE | grep -q "${LEADING_SLASH}.*/.*/"; then
+      SUBSYSTEM=${LINE%/*/}/
+      if grep -q -x "$SUBSYSTEM" $CMSSW_BASE/src/.git/info/sparse-checkout; then
+        echo "!$LINE" >> $CMSSW_BASE/src/.git/info/sparse-checkout
+      fi
+    fi
+  done
 fi
+rm -f $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
+
+# sort, keep exclusion lines at end
+grep -v "^\!" $CMSSW_BASE/src/.git/info/sparse-checkout | sort -u > $CMSSW_BASE/src/.git/info/sparse-checkout-new
+grep "^\!" $CMSSW_BASE/src/.git/info/sparse-checkout | sort -u >> $CMSSW_BASE/src/.git/info/sparse-checkout-new
+mv $CMSSW_BASE/src/.git/info/sparse-checkout-new $CMSSW_BASE/src/.git/info/sparse-checkout
 
 # update the working area
 git read-tree -mu HEAD

--- a/git-cms-rmpkg
+++ b/git-cms-rmpkg
@@ -1,0 +1,1 @@
+git-cms-addpkg


### PR DESCRIPTION
This new tool follows the same approach as #79, where the existing script (`cms-addpkg`) behaves differently depending on the command name. It required some refactoring here, but I think the end result is reasonably concise.

I also made sure the script refers to `$CMSSW_BASE/src/.git` consistently - some commands just used `.git`, which could inconsistencies.