### PR TITLE
use cms-addpkg in cms-checkdeps

### DIFF
--- a/git-cms-checkdeps
+++ b/git-cms-checkdeps
@@ -236,7 +236,7 @@ if ( $len > 0 ) {
         foreach my $pk (@t) {
             print $fh "$pk/\n";
         }
-        system("cd $ENV{CMSSW_BASE}/src; cat $fname >> $ENV{CMSSW_BASE}/src/.git/info/sparse-checkout; git read-tree -mu HEAD");
+        system("cd $ENV{CMSSW_BASE}/src; git cms-addpkg -f $fname -q");
         $exitcode+=$?;
         close($fh);
     }


### PR DESCRIPTION
One-line change to use `cms-addpkg` in `cms-checkdeps` to checkout packages when the `-a` option is enabled. `cms-addpkg` is run in quiet mode since `cms-checkdeps` has its own format for printing the list of packages that will be checked out.

This is desirable after #80 to keep the `sparse-checkout` file in a consistent state, e.g. in a corner case where the user adds a subsystem, removes a package from that subsystem, and then edits another package on which the removed package depends.