### PR TITLE
use cmssw.git reference from cvmfs if available

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -251,16 +251,13 @@ fi
 
 # check if a shared reference repository is available, otherwise set up a personal one
 if [ "$CMSSW_GIT_REFERENCE" = "" ]; then
-  case `hostname -f` in
-    *.cern.ch)
-      if [ -e /afs/cern.ch/cms/git-cmssw-mirror/cmssw.git ]; then
-        CMSSW_GIT_REFERENCE=/afs/cern.ch/cms/git-cmssw-mirror/cmssw.git
-      else
-        CMSSW_GIT_REFERENCE=~/.cmsgit-cache
-      fi
-    ;;
-    *) CMSSW_GIT_REFERENCE=~/.cmsgit-cache ;;
-  esac
+  if [ -e /cvmfs/cms-ib.cern.ch/git/cms-sw/cmssw.git ] ; then
+    CMSSW_GIT_REFERENCE=/cvmfs/cms-ib.cern.ch/git/cms-sw/cmssw.git
+  elif [ -e /cvmfs/cms.cern.ch/cmssw.git.daily ] ; then
+    CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
+  else
+    CMSSW_GIT_REFERENCE=~/.cmsgit-cache
+  fi
 fi
 
 if [ ! -e $CMSSW_GIT_REFERENCE ]; then


### PR DESCRIPTION
- /cvmfs/cms-ib.cern.ch/git/cms-sw/cmssw.git is updated as soon as something is committed in to cmssw repository (plus with cvmfs sync delays b/w CVMFS Stratum 0 to Stratum1's)
- /cvmfs/cms.cern.ch/cmssw.git.daily is updated once a day