### PR TITLE
add -A option for checkdeps in merge-topic & checkout-topic

### DIFF
--- a/docs/man/git-cms-checkout-topic.1.in
+++ b/docs/man/git-cms-checkout-topic.1.in
@@ -38,6 +38,13 @@ Access GitHub over ssh.
 
 Do not perform checkdeps at the end of the checkout.
 
+.TP 5
+
+-A, --all-deps
+
+Perform checkdeps for all dependencies (header, python, BuildFile).
+(Default: header, python.)
+
 .SH DESCRIPTION
 
 This is an alternate mode for git-cms-merge-topic.

--- a/docs/man/git-cms-merge-topic.1.in
+++ b/docs/man/git-cms-merge-topic.1.in
@@ -56,6 +56,13 @@ Specify strategy option when merging (see git merge documentation).
 
 Do not perform checkdeps at the end of the checkout.
 
+.TP 5
+
+-A, --all-deps
+
+Perform checkdeps for all dependencies (header, python, BuildFile).
+(Default: header, python.)
+
 .SH DESCRIPTION
 
 This is the git equivalent of the old CVS cmstc tagset <tagset-id> command.

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -24,6 +24,8 @@ usage() {
     $ECHO "-X, --strategy-option     \tspecify strategy option when merging"
   fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
+  $ECHO "-A, --all-deps     \tperform checkdeps for all dependencies (header, python, BuildFile)"
+  $ECHO "                   \t(default: header, python)"
   exit $CODE
 }
 
@@ -43,6 +45,10 @@ while [ $# -gt 0 ]; do
   case $1 in 
     -u|--unsafe)
       UNSAFE=true
+      shift
+      ;;
+    -A|--all-deps)
+      ALLCHECKDEPS=-A
       shift
       ;;
     -d|--debug)
@@ -199,5 +205,5 @@ fi
 git branch -D $TEMP_BRANCH >&${debug} || true
 # Do checkdeps unless not specified.
 if [ ! "X$UNSAFE" = Xtrue ]; then
-  git cms-checkdeps -a
+  git cms-checkdeps -a $ALLCHECKDEPS
 fi


### PR DESCRIPTION
As discussed with @smuzaffar in #80, this option will allow further simplification of the patch release build commands:
```
scram p $BASE_REL
cd $BASE_REL/src/
cmsenv
git cms-checkout-topic -A $PATCH_REL
git cms-addpkg -y FWCore/Version
```
