### PR TITLE
Add cms-rebase-topic and automatic backup branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-doc: docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1
+doc: docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1 docs/man/man1/git-cms-checkout-topic.1 docs/man/man1/git-cms-rebase-topic.1
 
 docs/man/man1/%.1: docs/man/%.1.in
 	nroff -man $< > $@

--- a/docs/man/git-cms-checkout-topic.1.in
+++ b/docs/man/git-cms-checkout-topic.1.in
@@ -34,6 +34,12 @@ Access GitHub over ssh.
 
 .TP 5
 
+-o, --old-base
+
+Specify old base for merge-base or rebase (not used by default).
+
+.TP 5
+
 -u, --unsafe
 
 Do not perform checkdeps at the end of the checkout.
@@ -48,7 +54,7 @@ Perform checkdeps for all dependencies (header, python, BuildFile).
 .SH DESCRIPTION
 
 This is an alternate mode for git-cms-merge-topic.
-It is useful to recreate a working area or rebase a branch,
+It is useful to recreate a working area or setup a patch release,
 by checking out only the packages modified
 in the specified branch (and their dependencies) without performing a merge.
 There are three different syntaxes, depending on whether you want to merge a pull

--- a/docs/man/git-cms-merge-topic.1.in
+++ b/docs/man/git-cms-merge-topic.1.in
@@ -34,6 +34,18 @@ Access GitHub over ssh.
 
 .TP 5
 
+-b, --backup
+
+Create backup branch before merging.
+
+.TP 5
+
+--backup-name
+
+Specify suffix for backup branch (default = _backup).
+
+.TP 5
+
 --no-commit
 
 Do not do the final commit when merging.

--- a/docs/man/git-cms-merge-topic.1.in
+++ b/docs/man/git-cms-merge-topic.1.in
@@ -34,9 +34,9 @@ Access GitHub over ssh.
 
 .TP 5
 
--b, --backup
+--no-backup 
 
-Create backup branch before merging.
+Don't create a backup branch.
 
 .TP 5
 

--- a/docs/man/git-cms-rebase-topic.1.in
+++ b/docs/man/git-cms-rebase-topic.1.in
@@ -1,16 +1,16 @@
-.TH GIT_CMS_MERGE_TOPIC 1 LOCAL
+.TH GIT_CMS_REBASE_TOPIC 1 LOCAL
 
 .SH NAME
 
-git-cms-merge-topic - CMSSW helper to merge a given branch or pull request into your workarea.
+git-cms-rebase-topic - CMSSW helper to rebase a given branch or pull request.
 
 .SH SYNOPSIS
 
-.B git cms-merge-topic <pull-request-id>
+.B git cms-rebase-topic <pull-request-id>
 
-.B git cms-merge-topic <official-cmssw-branch>
+.B git cms-rebase-topic <official-cmssw-branch>
 
-.B git cms-merge-topic <github-user>:<branch>
+.B git cms-rebase-topic <github-user>:<branch>
 
 .SH OPTIONS
 
@@ -46,12 +46,6 @@ Specify suffix for backup branch (default = _backup).
 
 .TP 5
 
---no-commit
-
-Do not do the final commit when merging.
-
-.TP 5
-
 -s, --strategy
 
 Specify strategy when merging (see git merge documentation).
@@ -70,6 +64,12 @@ Specify old base for merge-base or rebase (not used by default).
 
 .TP 5
 
+-n, --new-base
+
+Specify new base for merge-base or rebase (default = $CMSSW_VERSION).
+
+.TP 5
+
 -u, --unsafe
 
 Do not perform checkdeps at the end of the checkout.
@@ -83,7 +83,18 @@ Perform checkdeps for all dependencies (header, python, BuildFile).
 
 .SH DESCRIPTION
 
-This is the git equivalent of the old CVS cmstc tagset <tagset-id> command.
+This is an alternate mode for git-cms-merge-topic.
+It is useful to rebase a branch or move to a new IB/release,
+by checking out only the packages modified
+in the specified branch (and their dependencies) and then performing a rebase.
+
+By default, it uses this rebase syntax:
+git rebase [new_base] [branch]
+If old_base is specified, it uses this rebase syntax:
+git rebase --onto [new_base] [old_base] [branch]
+If you want access to advanced options for rebase, use git-cms-checkout-topic
+and then call git rebase manually.
+
 There are three different syntaxes, depending on whether you want to merge a pull
 request (specified via its numeric id, <pull-request-id>), a generic branch in
 the official-cmssw (https://github.com/cms-sw/cmssw) repository, or a branch in

--- a/docs/man/git-cms-rebase-topic.1.in
+++ b/docs/man/git-cms-rebase-topic.1.in
@@ -34,9 +34,9 @@ Access GitHub over ssh.
 
 .TP 5
 
--b, --backup
+--no-backup
 
-Create backup branch before merging.
+Don't create a backup branch.
 
 .TP 5
 

--- a/docs/man/man1/git-cms-addpkg.1
+++ b/docs/man/man1/git-cms-addpkg.1
@@ -3,52 +3,55 @@ GIT_CMS_ADDPKG(1)                                            GIT_CMS_ADDPKG(1)
 
 
 NNAAMMEE
-       git‐cms‐addpkg  ‐ CMSSW helper to checkout single packages from the git
-       repository.
+       git-cms-addpkg  - CMSSW helper to checkout single packages from the git
+       repository in the working area.
 
 
 SSYYNNOOPPSSIISS
-       ggiitt ccmmss‐‐aaddddppkkgg [[ooppttiioonnss]] <<ppaacckkaaggee>> [[<<ttaagg>>]]
+       ggiitt ccmmss--aaddddppkkgg [[ooppttiioonnss]] <<ssuubbssyysstteemm//ppaacckkaaggee>> [[<<ssuubbssyysstteemm//ppaacckkaaggee>>  ......]]
+
+       ggiitt ccmmss--aaddddppkkgg [[ooppttiioonnss]] --ff FFIILLEE
 
 
 DDEESSCCRRIIPPTTIIOONN
-       This is the git equivalent of the old CVS addpkg commant. <package>  is
-       the  package  you  want to checkout (e.g. FWCore/Version), <tag> is the
-       optional release tag which you want to checkout. By default it will use
-       the tag used for the current release area.
+       This  is the git equivalent of the old CVS addpkg command. <package> is
+       the package you want to checkout (e.g. FWCore/Version), or  <subsystem>
+       is  the  subsystem  you  want  to checkout (e.g. FWCore).  If the local
+       repository has not been initialized, it will call git-cms-init.
 
 
 OOPPTTIIOONNSS
-       The  defaults  should be just fine, however you can fine tune output of
-       the command with the following options.
+       -d, --debug
+
+            enable debug output
 
 
 
-       ‐d, ‐‐debug
+       -f, --file FILE
 
-            enable debug output"
-
-
-
-       ‐f, ‐‐force
-
-            force dangerous operations
+            read the list of packages to be checked out from FILE
 
 
 
-       ‐‐https
-
-            use https, rather than ssh to access your personal repository
-
-
-
-       ‐q, ‐‐quiet
+       -q, --quiet, -z
 
             do not print out progress
 
 
 
-       ‐y, ‐‐yes
+       --https
+
+            use https, rather than ssh to access your personal repository
+
+
+
+       --ssh
+
+            use ssh, rather than https to access the official repository
+
+
+
+       -y, --yes
 
             assume yes to all questions
 

--- a/docs/man/man1/git-cms-checkout-topic.1
+++ b/docs/man/man1/git-cms-checkout-topic.1
@@ -1,0 +1,68 @@
+GIT_CMS_CHECKOUT_TOPIC(1)                            GIT_CMS_CHECKOUT_TOPIC(1)
+
+
+
+NNAAMMEE
+       git-cms-checkout-topic  -  CMSSW  helper  to checkout a given branch or
+       pull request into your workarea (without merging).
+
+
+SSYYNNOOPPSSIISS
+       ggiitt ccmmss--cchheecckkoouutt--ttooppiicc <<ppuullll--rreeqquueesstt--iidd>>
+
+       ggiitt ccmmss--cchheecckkoouutt--ttooppiicc <<ooffffiicciiaall--ccmmssssww--bbrraanncchh>>
+
+       ggiitt ccmmss--cchheecckkoouutt--ttooppiicc <<ggiitthhuubb--uusseerr>>::<<bbrraanncchh>>
+
+
+OOPPTTIIOONNSS
+       -d, --debug
+
+            Enable debug output.
+
+
+
+       --https
+
+            Access GitHub over https (default).
+
+
+
+       --ssh
+
+            Access GitHub over ssh.
+
+
+
+       -o, --old-base
+
+            Specify old base for merge-base or rebase (not used by default).
+
+
+
+       -u, --unsafe
+
+            Do not perform checkdeps at the end of the checkout.
+
+
+
+       -A, --all-deps
+
+            Perform checkdeps for all  dependencies  (header,  python,  Build-
+            File).  (Default: header, python.)
+
+
+DDEESSCCRRIIPPTTIIOONN
+       This  is  an  alternate  mode for git-cms-merge-topic.  It is useful to
+       recreate a working area or setup a patch release, by checking out  only
+       the  packages modified in the specified branch (and their dependencies)
+       without performing  a  merge.   There  are  three  different  syntaxes,
+       depending  on  whether  you want to merge a pull request (specified via
+       its numeric id, <pull-request-id>), a generic branch in  the  official-
+       cmssw  (https://github.com/cms-sw/cmssw) repository, or a branch in the
+       repository of some other github user (specified by its github username,
+       <github-user>).
+
+
+
+                                     LOCAL           GIT_CMS_CHECKOUT_TOPIC(1)

--- a/docs/man/man1/git-cms-merge-topic.1
+++ b/docs/man/man1/git-cms-merge-topic.1
@@ -3,31 +3,94 @@ GIT_CMS_MERGE_TOPIC(1)                                  GIT_CMS_MERGE_TOPIC(1)
 
 
 NNAAMMEE
-       git‐cms‐merge‐topic  ‐  CMSSW  helper  to  merge a given branch or pull
+       git-cms-merge-topic  -  CMSSW  helper  to  merge a given branch or pull
        request into your workarea.
 
 
 SSYYNNOOPPSSIISS
-       ggiitt ccmmss‐‐mmeerrggee‐‐ttooppiicc <<ppuullll‐‐rreeqquueesstt‐‐iidd>>
+       ggiitt ccmmss--mmeerrggee--ttooppiicc <<ppuullll--rreeqquueesstt--iidd>>
 
-       ggiitt ccmmss‐‐mmeerrggee‐‐ttooppiicc <<ooffffiicciiaall‐‐ccmmssssww‐‐bbrraanncchh>>
+       ggiitt ccmmss--mmeerrggee--ttooppiicc <<ooffffiicciiaall--ccmmssssww--bbrraanncchh>>
 
-       ggiitt ccmmss‐‐mmeerrggee‐‐ttooppiicc <<ggiitthhuubb‐‐uusseerr>>::<<bbrraanncchh>>
+       ggiitt ccmmss--mmeerrggee--ttooppiicc <<ggiitthhuubb--uusseerr>>::<<bbrraanncchh>>
 
 
 OOPPTTIIOONNSS
-       ‐u, ‐‐unsafe
+       -d, --debug
+
+            Enable debug output.
+
+
+
+       --https
+
+            Access GitHub over https (default).
+
+
+
+       --ssh
+
+            Access GitHub over ssh.
+
+
+
+       --no-backup
+
+            Don’t create a backup branch.
+
+
+
+       --backup-name
+
+            Specify suffix for backup branch (default = _backup).
+
+
+
+       --no-commit
+
+            Do not do the final commit when merging.
+
+
+
+       -s, --strategy
+
+            Specify strategy when merging (see git merge documentation).
+
+
+
+       -X, --strategy-option
+
+            Specify strategy option when merging  (see  git  merge  documenta-
+            tion).
+
+
+
+       -o, --old-base
+
+            Specify old base for merge-base or rebase (not used by default).
+
+
+
+       -u, --unsafe
 
             Do not perform checkdeps at the end of the checkout.
 
 
+
+       -A, --all-deps
+
+            Perform  checkdeps  for  all  dependencies (header, python, Build-
+            File).  (Default: header, python.)
+
+
 DDEESSCCRRIIPPTTIIOONN
-       This is the git equivalent of the old CVS cmstc tagset <tagset‐id> com‐
-       mand.   There  are three different syntax, depending on wether you want
-       to merge a pull request (specified via its numeric  id,  <pull‐request‐
-       id>),  a  generic branch in the official‐cmssw (https://github.com/cms‐
-       sw/cmssw) repository, or a branch  in  the  repository  of  some  other
-       github user (specified by its github username, <github‐user>).
+       This is the git equivalent of the old CVS cmstc tagset <tagset-id> com-
+       mand.   There  are  three  different syntaxes, depending on whether you
+       want to merge a pull request (specified  via  its  numeric  id,  <pull-
+       request-id>),     a    generic    branch    in    the    official-cmssw
+       (https://github.com/cms-sw/cmssw) repository, or a branch in the repos-
+       itory  of  some  other  github  user (specified by its github username,
+       <github-user>).
 
 
 

--- a/docs/man/man1/git-cms-rebase-topic.1
+++ b/docs/man/man1/git-cms-rebase-topic.1
@@ -1,0 +1,107 @@
+GIT_CMS_REBASE_TOPIC(1)                                GIT_CMS_REBASE_TOPIC(1)
+
+
+
+NNAAMMEE
+       git-cms-rebase-topic  -  CMSSW  helper to rebase a given branch or pull
+       request.
+
+
+SSYYNNOOPPSSIISS
+       ggiitt ccmmss--rreebbaassee--ttooppiicc <<ppuullll--rreeqquueesstt--iidd>>
+
+       ggiitt ccmmss--rreebbaassee--ttooppiicc <<ooffffiicciiaall--ccmmssssww--bbrraanncchh>>
+
+       ggiitt ccmmss--rreebbaassee--ttooppiicc <<ggiitthhuubb--uusseerr>>::<<bbrraanncchh>>
+
+
+OOPPTTIIOONNSS
+       -d, --debug
+
+            Enable debug output.
+
+
+
+       --https
+
+            Access GitHub over https (default).
+
+
+
+       --ssh
+
+            Access GitHub over ssh.
+
+
+
+       --no-backup
+
+            Don’t create a backup branch.
+
+
+
+       --backup-name
+
+            Specify suffix for backup branch (default = _backup).
+
+
+
+       -s, --strategy
+
+            Specify strategy when merging (see git merge documentation).
+
+
+
+       -X, --strategy-option
+
+            Specify strategy option when merging  (see  git  merge  documenta-
+            tion).
+
+
+
+       -o, --old-base
+
+            Specify old base for merge-base or rebase (not used by default).
+
+
+
+       -n, --new-base
+
+            Specify  new  base for merge-base or rebase (default = $CMSSW_VER-
+            SION).
+
+
+
+       -u, --unsafe
+
+            Do not perform checkdeps at the end of the checkout.
+
+
+
+       -A, --all-deps
+
+            Perform checkdeps for all  dependencies  (header,  python,  Build-
+            File).  (Default: header, python.)
+
+
+DDEESSCCRRIIPPTTIIOONN
+       This  is  an  alternate  mode for git-cms-merge-topic.  It is useful to
+       rebase a branch or move to a new IB/release, by checking out  only  the
+       packages  modified in the specified branch (and their dependencies) and
+       then performing a rebase.
+
+       By default, it uses this rebase syntax: git rebase [new_base]  [branch]
+       If old_base is specified, it uses this rebase syntax: git rebase --onto
+       [new_base] [old_base] [branch] If you want access to  advanced  options
+       for  rebase,  use git-cms-checkout-topic and then call git rebase manu-
+       ally.
+
+       There are three different syntaxes, depending on whether  you  want  to
+       merge a pull request (specified via its numeric id, <pull-request-id>),
+       a  generic  branch  in  the   official-cmssw   (https://github.com/cms-
+       sw/cmssw)  repository,  or  a  branch  in  the repository of some other
+       github user (specified by its github username, <github-user>).
+
+
+
+                                     LOCAL             GIT_CMS_REBASE_TOPIC(1)

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -148,7 +148,7 @@ TEMP_BRANCH=${TEMP_BRANCH_WORD}-attempt
 
 # initialize the local repository
 if [ -z "$CMSSW_BASE" ]; then
-  echo "CMSSW environment not setup, please run 'cmsenv' before 'git cms-merge-topic'."
+  echo "CMSSW environment not setup, please run 'cmsenv' before 'git $COMMAND_NAME'."
   exit 1
 fi
 if ! [ -d $CMSSW_BASE/src/.git ]; then

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -20,7 +20,7 @@ usage() {
   $ECHO "    --ssh          \taccess GitHub over ssh"
   # not for checkout-topic
   if [ "$COMMAND_NAME" != "cms-checkout-topic" ]; then
-    $ECHO "-b, --backup       \tcreate backup branch"
+    $ECHO "    --no-backup       \tdon't create backup branch"
     $ECHO "    --backup-name  \tspecify suffix for backup branch (default = _backup)"
     $ECHO "-s, --strategy     \tspecify strategy when merging"
     $ECHO "-X, --strategy-option     \tspecify strategy option when merging"
@@ -46,6 +46,7 @@ NORMAL='\033[0m'
 
 DEBUG=0
 PROTOCOL=https
+BACKUP=true
 BACKUP_NAME=_backup
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
@@ -79,8 +80,8 @@ while [ $# -gt 0 ]; do
       NO_COMMIT=--no-commit 
       shift
       ;;
-    -b | --backup )
-      BACKUP=true
+    --no-backup )
+      BACKUP=""
       shift
       ;;
     --backup-name )

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -18,12 +18,21 @@ usage() {
   $ECHO "-d, --debug        \tenable debug output"
   $ECHO "    --https        \taccess GitHub over https (default)"
   $ECHO "    --ssh          \taccess GitHub over ssh"
-  if [ "$COMMAND_NAME" = "cms-merge-topic" ]; then
+  # not for checkout-topic
+  if [ "$COMMAND_NAME" != "cms-checkout-topic" ]; then
     $ECHO "-b, --backup       \tcreate backup branch"
     $ECHO "    --backup-name  \tspecify suffix for backup branch (default = _backup)"
-    $ECHO "    --no-commit    \tdo not do the final commit when merging"
     $ECHO "-s, --strategy     \tspecify strategy when merging"
     $ECHO "-X, --strategy-option     \tspecify strategy option when merging"
+  fi
+  # only for merge-topic
+  if [ "$COMMAND_NAME" = "cms-merge-topic" ]; then
+    $ECHO "    --no-commit    \tdo not do the final commit when merging"
+  fi
+  $ECHO "-o, --old-base       \tspecify old base for merge-base or rebase (not used by default)"
+  # only for rebase-topic
+  if [ "$COMMAND_NAME" = "cms-rebase-topic" ]; then
+    $ECHO "-n, --new-base       \tspecify new base for rebase (default = "'$CMSSW_VERSION'")"
   fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
   $ECHO "-A, --all-deps     \tperform checkdeps for all dependencies (header, python, BuildFile)"
@@ -40,7 +49,7 @@ PROTOCOL=https
 BACKUP_NAME=_backup
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
-if [ "$COMMAND_NAME" = "cms-checkout-topic" ]; then
+if [ "$COMMAND_NAME" = "cms-checkout-topic" ] || [ "$COMMAND_NAME" = "cms-rebase-topic" ]; then
   NOMERGE=true
 fi
 
@@ -84,6 +93,14 @@ while [ $# -gt 0 ]; do
       ;;
     -X | --strategy-option )
       STRATEGY_OPTION="-X $2"
+      shift; shift
+      ;;
+    -o | --old-base )
+      OLD_BASE=$2
+      shift; shift
+      ;;
+    -n | --new-base )
+      NEW_BASE=$2
       shift; shift
       ;;
     -h|--help)
@@ -151,16 +168,16 @@ fi
 
 PULL_ID=$1
 
-TEMP_BRANCH_WORD=merge
-if [ "X$NOMERGE" = Xtrue ]; then
-  TEMP_BRANCH_WORD=checkout
-fi
+TEMP_BRANCH_WORD=$(echo $COMMAND_NAME | cut -d'-' -f2)
 TEMP_BRANCH=${TEMP_BRANCH_WORD}-attempt
 
 # initialize the local repository
 if [ -z "$CMSSW_BASE" ]; then
   echo "CMSSW environment not setup, please run 'cmsenv' before 'git $COMMAND_NAME'."
   exit 1
+fi
+if [ -z "$NEW_BASE" ]; then
+  NEW_BASE=$CMSSW_VERSION
 fi
 if ! [ -d $CMSSW_BASE/src/.git ]; then
   git cms-init $INITOPTIONS
@@ -193,7 +210,12 @@ git fetch -n $REPOSITORY +$COMMIT:$GITHUB_USER/$BRANCH
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 # Attempt a merge in a separate branch
 git checkout $TEMP_BRANCH >&${debug}
-MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $CURRENT_BRANCH`
+if [ -n "$OLD_BASE" ]; then
+  MERGE_BASE_BRANCH=$OLD_BASE
+else
+  MERGE_BASE_BRANCH=$CURRENT_BRANCH
+fi
+MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $MERGE_BASE_BRANCH`
 git cms-sparse-checkout $DEBUG_OPT $MERGE_BASE $GITHUB_USER/$BRANCH
 git read-tree -mu HEAD
 
@@ -206,6 +228,15 @@ fi
 if [ "$NOMERGE" = "true" ]; then
   git checkout -b $LOCAL_BRANCH $GITHUB_USER/$BRANCH
   echo "Created branch $LOCAL_BRANCH to follow $BRANCH from repository $GITHUB_USER"
+  # now try a rebase if desired
+  if [ "$COMMAND_NAME" = "cms-rebase-topic" ]; then
+    if [ -n "$OLD_BASE" ]; then
+      $ECHO "git rebase $MERGE_STRATEGY $STRATEGY_OPTION --onto $NEW_BASE $OLD_BASE $LOCAL_BRANCH"
+      git rebase $MERGE_STRATEGY $STRATEGY_OPTION --onto $NEW_BASE $OLD_BASE $LOCAL_BRANCH
+    else
+      git rebase $MERGE_STRATEGY $STRATEGY_OPTION $NEW_BASE $LOCAL_BRANCH
+    fi
+  fi
 # otherwise, perform merge
 else
   git merge $NO_COMMIT $MERGE_STRATEGY $STRATEGY_OPTION --no-ff -m "Merged $BRANCH from repository $GITHUB_USER" $GITHUB_USER/$BRANCH || { echo "Unable to merge branch $BRANCH from repository $GITHUB_USER." ; exit 1; }

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -19,6 +19,8 @@ usage() {
   $ECHO "    --https        \taccess GitHub over https (default)"
   $ECHO "    --ssh          \taccess GitHub over ssh"
   if [ "$COMMAND_NAME" = "cms-merge-topic" ]; then
+    $ECHO "-b, --backup       \tcreate backup branch"
+    $ECHO "    --backup-name  \tspecify suffix for backup branch (default = _backup)"
     $ECHO "    --no-commit    \tdo not do the final commit when merging"
     $ECHO "-s, --strategy     \tspecify strategy when merging"
     $ECHO "-X, --strategy-option     \tspecify strategy option when merging"
@@ -35,6 +37,7 @@ NORMAL='\033[0m'
 
 DEBUG=0
 PROTOCOL=https
+BACKUP_NAME=_backup
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
 if [ "$COMMAND_NAME" = "cms-checkout-topic" ]; then
@@ -66,6 +69,14 @@ while [ $# -gt 0 ]; do
     --no-commit )
       NO_COMMIT=--no-commit 
       shift
+      ;;
+    -b | --backup )
+      BACKUP=true
+      shift
+      ;;
+    --backup-name )
+      BACKUP_NAME=$2
+      shift; shift
       ;;
     -s | --strategy )
       MERGE_STRATEGY="-s $2"
@@ -185,6 +196,12 @@ git checkout $TEMP_BRANCH >&${debug}
 MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $CURRENT_BRANCH`
 git cms-sparse-checkout $DEBUG_OPT $MERGE_BASE $GITHUB_USER/$BRANCH
 git read-tree -mu HEAD
+
+# optional backup
+if [ "$BACKUP" = "true" ]; then
+  git branch ${LOCAL_BRANCH}${BACKUP_NAME} $GITHUB_USER/$BRANCH
+fi
+
 # in no-merge case, just checkout a new branch
 if [ "$NOMERGE" = "true" ]; then
   git checkout -b $LOCAL_BRANCH $GITHUB_USER/$BRANCH

--- a/git-cms-rebase-topic
+++ b/git-cms-rebase-topic
@@ -1,0 +1,1 @@
+git-cms-merge-topic


### PR DESCRIPTION
* add a tool `cms-rebase-topic` that is an extension of `cms-checkout-topic` that calls rebase after checking out the branch
* extended rebase syntax (`--onto`) can be activated using the `old-base` option (in case of backports, diverging branches, etc.); the specified old base is also used for the `merge-base` calculation (in any of the related tools; sometimes it's nice to checkout a branch in an old release without getting every package in CMSSW)
* `cms-rebase-topic` and `cms-merge-topic` create a backup branch (named `..._backup`) by default before rebasing or merging, to standardize recovery instructions for users
* actually ran `make` to update the man pages from source (which hadn't been done in a while)