### PR TITLE
Add support for .clang-tidy and .clang-format

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -390,8 +390,11 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
 
   # setup sparse checkout
   git config core.sparsecheckout true
-  echo "${LEADING_SLASH}.gitignore" > $CMSSW_BASE/src/.git/info/sparse-checkout
-  git checkout $CMSSW_BRANCH -- .gitignore
+  {
+    echo "${LEADING_SLASH}.gitignore"
+    echo "${LEADING_SLASH}.clang-tidy"
+    echo "${LEADING_SLASH}.clang-format"
+  } > $CMSSW_BASE/src/.git/info/sparse-checkout
   git read-tree -mu HEAD
 fi
 

--- a/git-cms-sparse-checkout
+++ b/git-cms-sparse-checkout
@@ -82,7 +82,7 @@ fi
 
 case `git --version` in 
   git\ version\ 1.7*)
-    # git 1.7.x does not support a leading slash in /gitignore and .git/info/sparse-checkout
+    # git 1.7.x does not support a leading slash in .gitignore and .git/info/sparse-checkout
     LEADING_SLASH=
   ;;
   *)


### PR DESCRIPTION
`git cms-init` will now add to the local area `.clang-tidy` (and `.clang-format` when it will be included in the release)