### PR TITLE
check if topic branch is behind release when using checkout-topic

### DIFF
--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -256,3 +256,10 @@ git branch -D $TEMP_BRANCH >&${debug} || true
 if [ ! "X$UNSAFE" = Xtrue ]; then
   git cms-checkdeps -a $ALLCHECKDEPS
 fi
+# check if topic branch is behind release branch
+if [ "$COMMAND_NAME" = "cms-checkout-topic" ]; then
+  NBEHIND=$(git rev-list $LOCAL_BRANCH..$CURRENT_BRANCH | wc -l)
+  if [ "$NBEHIND" -gt 0 ]; then
+    $ECHO "Warning: $LOCAL_BRANCH is behind $CURRENT_BRANCH. You may not be able to compile or run."
+  fi
+fi


### PR DESCRIPTION
Requested by @makortel. Tested w/ `CMSSW_10_0_X_2017-11-14-2300` and `git cms-checkout-topic 20879`, in this case, it prints:
```
Warning: pull/20879 is behind from-CMSSW_10_0_X_2017-11-14-2300. You may not be able to compile or run.
```
If instead using `CMSSW_10_0_X_2017-11-14-1100`, no message is printed (as expected).

The message is printed *after* checkdeps, so the user doesn't miss the message in case checkdeps has a long list.