### PR TITLE
Allow reuse of topic commands

### DIFF
--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -220,8 +220,8 @@ MERGE_BASE=`git merge-base $GITHUB_USER/$BRANCH $MERGE_BASE_BRANCH`
 git cms-sparse-checkout $DEBUG_OPT $MERGE_BASE $GITHUB_USER/$BRANCH
 git read-tree -mu HEAD
 
-# optional backup
-if [ "$BACKUP" = "true" ]; then
+# optional backup (not for checkout-topic)
+if [ "$BACKUP" = "true" ] && [ "$COMMAND_NAME" != "cms-checkout-topic" ]; then
   git branch ${LOCAL_BRANCH}${BACKUP_NAME} $GITHUB_USER/$BRANCH
 fi
 

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -222,12 +222,12 @@ git read-tree -mu HEAD
 
 # optional backup (not for checkout-topic)
 if [ "$BACKUP" = "true" ] && [ "$COMMAND_NAME" != "cms-checkout-topic" ]; then
-  git branch ${LOCAL_BRANCH}${BACKUP_NAME} $GITHUB_USER/$BRANCH
+  git branch -f ${LOCAL_BRANCH}${BACKUP_NAME} $GITHUB_USER/$BRANCH
 fi
 
 # in no-merge case, just checkout a new branch
 if [ "$NOMERGE" = "true" ]; then
-  git checkout -b $LOCAL_BRANCH $GITHUB_USER/$BRANCH
+  git checkout -B $LOCAL_BRANCH $GITHUB_USER/$BRANCH
   echo "Created branch $LOCAL_BRANCH to follow $BRANCH from repository $GITHUB_USER"
   # now try a rebase if desired
   if [ "$COMMAND_NAME" = "cms-rebase-topic" ]; then


### PR DESCRIPTION
Currently, trying to reuse any of the `cms-...-topic` commands with the same remote branch produces error messages like `fatal: A branch named 'foo_backup' already exists.` or `fatal: A branch named 'foo' already exists.`.

The easiest way to fix this is just to overwrite the branch and the backup branch by default (assuming that if the user wants to keep any of these branches, they can rename them, or change the name of the backup branch).

Also noticed that `cms-checkout-topic` was making a backup branch for no reason (it's not supposed to - the relevant arguments aren't shown in the usage), so disabled that.