### PR TITLE
The return of cms-rmpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-doc: docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1 docs/man/man1/git-cms-checkout-topic.1 docs/man/man1/git-cms-rebase-topic.1
+doc: docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1 docs/man/man1/git-cms-checkout-topic.1 docs/man/man1/git-cms-rebase-topic.1 docs/man/man1/git-cms-rmpkg.1
 
 docs/man/man1/%.1: docs/man/%.1.in
 	mkdir -p $(@D)

--- a/docs/man/git-cms-rmpkg.1.in
+++ b/docs/man/git-cms-rmpkg.1.in
@@ -37,3 +37,9 @@ read the list of packages to be checked out from FILE
 -q, --quiet, -z
 
 do not print out progress
+
+.TP 5
+
+-o, --force
+
+force removal of packages even if modified or containing untracked files

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -27,23 +27,13 @@ usage () {
   exit $2
 }
 
-checkPkgFile () {
-  INPUT_FILE="$1"
-  CURRENT_BRANCH="$2"
-  for PKG_NAME in `cat $INPUT_FILE`; do
-    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
-      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
-      echo $PKG_NAME
-    fi
-  done
-  if [ "$HEADER" ]; then
-    exit 1
-  fi
-}
-
-checkPkgList () {
+checkPkgs () {
   PACKAGES="$1"
   CURRENT_BRANCH="$2"
+  FILE="$3"
+  if [ -n "$FILE" ]; then
+    PACKAGES=`cat $PACKAGES`
+  fi
   for PKG_NAME in $PACKAGES; do
     if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
       [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
@@ -227,9 +217,9 @@ CURRENT_BRANCH=`git symbolic-ref --short HEAD`
 # check if requested packages are present to be removed
 if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
   if [ "$INPUT_FILE" ]; then
-    checkPkgFile "$INPUT_FILE" "$CURRENT_BRANCH"
+    checkPkgs "$INPUT_FILE" "$CURRENT_BRANCH" file
   else
-    checkPkgList "$PACKAGES" "$CURRENT_BRANCH"
+    checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
   fi
 fi
 
@@ -291,9 +281,9 @@ git read-tree -mu HEAD
 # check if requested packages were successfully added
 if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
   if [ "$INPUT_FILE" ]; then
-    checkPkgFile "$INPUT_FILE" "$CURRENT_BRANCH"
+    checkPkgs "$INPUT_FILE" "$CURRENT_BRANCH" file
   else
-    checkPkgList "$PACKAGES" "$CURRENT_BRANCH"
+    checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
   fi
   exit 0
 fi

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -114,10 +114,6 @@ fi
 checkPkgs () {
   PACKAGES="$1"
   CURRENT_BRANCH="$2"
-  FILE="$3"
-  if [ -n "$FILE" ]; then
-    PACKAGES=$(< $PACKAGES)
-  fi
   for PKG_NAME in $PACKAGES; do
     if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
       [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
@@ -186,8 +182,10 @@ else
 fi
 
 if [ "$INPUT_FILE" ]; then
+  # make it into a standard package list
+  PACKAGES=`cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$'`
   # check the syntax of the input file
-  INVALID=`cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | grep -v -E '^/*\w+(/\w+)?/*$' || true`
+  INVALID=`echo $PACKAGES | tr " " "\n" | grep -v -E '^/*\w+(/\w+)?/*$' || true`
   if [ -n "$INVALID" ]; then
     $ECHO "Some lines of $INPUT_FILE are not in a valid format:"
     $ECHO "$RED$INVALID$NORMAL"
@@ -241,32 +239,18 @@ CURRENT_BRANCH=`git symbolic-ref --short HEAD`
 
 # check if requested packages are present to be removed
 if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
-  if [ "$INPUT_FILE" ]; then
-    checkPkgs "$INPUT_FILE" "$CURRENT_BRANCH" file
-  else
-    checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
-  fi
+  checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
 fi
 
 # create temporary sparse checkout file
 touch $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
 
 # add the requested package(s) to the temporary file
-if [ "$INPUT_FILE" ]; then
-  verbose "\n$ACTION packages"
-  verbose "`cat "$INPUT_FILE"`"
-
-  cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
-else
-  verbose "\n$ACTION packages"
-  for PKG_NAME in $PACKAGES; do
-    verbose $PKG_NAME
-  done
-
-  for PKG_NAME in $PACKAGES; do
-    echo $PKG_NAME | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
-  done
-fi
+verbose "\n$ACTION packages"
+for PKG_NAME in $PACKAGES; do
+  verbose $PKG_NAME
+  echo $PKG_NAME | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
+done
 
 # add or remove from the real sparse checkout file
 if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
@@ -305,10 +289,6 @@ git read-tree -mu HEAD
 
 # check if requested packages were successfully added
 if [ "$COMMAND_NAME" == "cms-addpkg" ]; then
-  if [ "$INPUT_FILE" ]; then
-    checkPkgs "$INPUT_FILE" "$CURRENT_BRANCH" file
-  else
-    checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
-  fi
+  checkPkgs "$PACKAGES" "$CURRENT_BRANCH"
   exit 0
 fi

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -116,7 +116,7 @@ checkPkgs () {
   CURRENT_BRANCH="$2"
   FILE="$3"
   if [ -n "$FILE" ]; then
-    PACKAGES=`cat $PACKAGES`
+    PACKAGES=$(< $PACKAGES)
   fi
   for PKG_NAME in $PACKAGES; do
     if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -49,7 +49,7 @@ NORMAL='\033[0m'
 
 verbose () {
   if [ "X$VERBOSE" = X1 ]; then
-    echo "$@"
+    $ECHO "$@"
   fi
 }
 

--- a/git-cms-addpkg
+++ b/git-cms-addpkg
@@ -23,26 +23,10 @@ usage () {
     $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"
     $ECHO "    --ssh          \tuse ssh, rather than https to access the official repository"
     $ECHO "-y, --yes          \tassume yes to all questions"
+  elif [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
+    $ECHO "-o, --force        \tforce removal of packages even if modified or containing untracked files"
   fi
   exit $2
-}
-
-checkPkgs () {
-  PACKAGES="$1"
-  CURRENT_BRANCH="$2"
-  FILE="$3"
-  if [ -n "$FILE" ]; then
-    PACKAGES=`cat $PACKAGES`
-  fi
-  for PKG_NAME in $PACKAGES; do
-    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
-      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
-      echo $PKG_NAME
-    fi
-  done
-  if [ "$HEADER" ]; then
-    exit 1
-  fi
 }
 
 COMMAND_NAME=$(basename $0 | sed -e's/^git-//')
@@ -57,6 +41,7 @@ VERBOSE=1
 INITOPTIONS=""                      # options passed to git cms-init
 PACKAGES=
 INPUT_FILE=
+FORCE=
 
 # colors and formatting
 RED='\033[31m'
@@ -101,6 +86,9 @@ while [ "$#" != 0 ]; do
     --ssh )
       INITOPTIONS="$INITOPTIONS $1"
       shift;;
+    -o | --force )
+      FORCE=true
+      shift;;
     -*)
       $ECHO "git cms-addpkg: unknown option $1"; $ECHO; usage $COMMAND_NAME 1;;
     *)
@@ -122,6 +110,43 @@ if [ "$PACKAGES" == "" ] && [ "$INPUT_FILE" == "" ] ; then
   $ECHO
   usage $COMMAND_NAME 1
 fi
+
+checkPkgs () {
+  PACKAGES="$1"
+  CURRENT_BRANCH="$2"
+  FILE="$3"
+  if [ -n "$FILE" ]; then
+    PACKAGES=`cat $PACKAGES`
+  fi
+  for PKG_NAME in $PACKAGES; do
+    if [ ! -d "$CMSSW_BASE/src/$PKG_NAME" ]; then
+      [ "$HEADER" ] || { $ECHO "\nThese packages do not exist in branch $CURRENT_BRANCH"; HEADER=done; }
+      echo $PKG_NAME
+    fi
+  done
+  if [ "$COMMAND_NAME" == "cms-rmpkg" ]; then
+    for PKG_NAME in $PACKAGES; do
+      UNTK=`git clean -xdn $CMSSW_BASE/src/$PKG_NAME`
+      if [ -n "$UNTK" ]; then
+        [ "$HEADER2" ] || { $ECHO "\nThese packages contain untracked files"; HEADER2=done; }
+        echo $PKG_NAME
+        if [ -n "$FORCE" ]; then
+          git clean -xdf $CMSSW_BASE/src/$PKG_NAME > /dev/null 2>&1
+        fi
+      fi
+    done
+    MODPKG=`git diff --name-only $CMSSW_VERSION..HEAD | cut -d'/' -f1-2 | sort -u`
+    for PKG_NAME in $PACKAGES; do
+      if [[ "$MODPKG" =~ "$PKG_NAME" ]]; then
+        [ "$HEADER3" ] || { $ECHO "\nThese packages have been modified from the base release"; HEADER3=done; }
+        echo $PKG_NAME
+      fi
+    done
+  fi
+  if [ "$HEADER" ] || (([ "$HEADER2" ] || [ "$HEADER3" ]) && [ -z "$FORCE" ]); then
+    exit 1
+  fi
+}
 
 BASH_FULL_VERSION=$((${BASH_VERSINFO[0]} * 10000 + ${BASH_VERSINFO[1]} * 100 + ${BASH_VERSINFO[2]}))
 if (( BASH_FULL_VERSION >= 40100 )); then
@@ -228,12 +253,12 @@ touch $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
 
 # add the requested package(s) to the temporary file
 if [ "$INPUT_FILE" ]; then
-  verbose "$ACTION packages"
+  verbose "\n$ACTION packages"
   verbose "`cat "$INPUT_FILE"`"
 
   cat "$INPUT_FILE" | sed -e's|\s*#.*||' | grep -v '^\s*$' | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $CMSSW_BASE/src/.git/info/sparse-checkout-tmp
 else
-  verbose "$ACTION packages"
+  verbose "\n$ACTION packages"
   for PKG_NAME in $PACKAGES; do
     verbose $PKG_NAME
   done

--- a/git-cms-rmpkg
+++ b/git-cms-rmpkg
@@ -1,0 +1,1 @@
+git-cms-addpkg


### PR DESCRIPTION
`cms-rmpkg` was originally introduced in #80, but then removed in #83. The problems were:

> * rmpkg can be used to delete a package which was part of a cms-merge-topic. In this case things can fail.
> * when we delete a package (after it has been built once) then it leaves the newly generated files e.g. package/python/*.pyc files in the area. This can also cause problems.
> * SCRAM/build rules also needs update to support rmpkg as it still create lib/$SCRAM_ARCH/.poisonededmplugincache file for the deleted plugins.

This PR addresses the first two concerns by:
* making a list of packages modified after the tag corresponding to `$CMSSW_VERSION` and stopping if any requested packages are on it
* making a list of packages containing untracked files (e.g. `.pyc`) and stopping if any requested packages are on it
* allows overriding the stop with `-o, --force` (will delete untracked files in that case)

Other changes in this PR:
* update documentation
* simplify logic for handling input files (just convert to a space-separated package list right away, then the rest of the code doesn't have to care if it's an input file or not)

Questions for others (@smuzaffar, @fwyzard, @davidlange6, anybody else who cares):
1. Are the messages printed for the special cases sufficient? (see below)
2. Right now, if given packages A and B, `cms-rmpkg` won't remove A if B triggers an error (because nonexistent, containing untracked files, or modified). Should we try to make it more permissive (e.g. remove anything it can remove)?
3. I don't know how to fix the SCRAM build rules to deal with packages that were removed but not deleted. Any ideas?

Tested as follows:
```
cmsrel CMSSW_10_1_0_pre2
cd CMSSW_10_1_0_pre2/src
cmsenv
git cms-addpkg RecoEgamma/PhotonIdentification Configuration/PyReleaseValidation
scram b -j 8
(add random comment to file in Configuration/PyReleaseValidation, commit change)
```

First test:
```
git cms-rmpkg RecoEgamma Configuration/PyReleaseValidation
```
gives:
```

These packages contain untracked files
RecoEgamma
Configuration/PyReleaseValidation

These packages have been modified from the base release
Configuration/PyReleaseValidation
```

Second test:
```
git cms-rmpkg -o RecoEgamma Configuration/PyReleaseValidation
```
gives:
```

These packages contain untracked files
RecoEgamma
Configuration/PyReleaseValidation

These packages have been modified from the base release
Configuration/PyReleaseValidation

Removing packages
RecoEgamma
Configuration/PyReleaseValidation
```