### PR TITLE
Minor updates to git-cms-init

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -19,6 +19,7 @@ usage () {
   $ECHO "    --https        \tuse https, rather than ssh to access your personal repository"
   $ECHO "    --ssh          \tuse ssh, rather than https to access the official repository"
   $ECHO "    --upstream-only\tconfigure only the official upstream repository, not the user repository"
+  $ECHO "-w, --enable-push  \tenable pushing to the official upstream repository"
   $ECHO "-q, --quiet, -z    \tdo not print out progress"
   $ECHO "-y, --yes          \tassume yes to all questions"
   exit $1
@@ -31,6 +32,7 @@ PROTOCOL=mixed
 DEBUG=false
 VERBOSE=true
 UPSTREAM_ONLY=false
+UPSTREAM_PUSH=false
 OAUTH_TOKEN=869cfb0477e0cae72fb233be5e1f02bd97905bad
 PROXY=`git config https.proxy` && PROXY="-x $PROXY"
 
@@ -67,6 +69,8 @@ while [ "$#" != 0 ]; do
       shift; PROTOCOL=https ;;
     --ssh )
       shift; PROTOCOL=ssh ;;
+    -w | --enable-push )
+      shift; UPSTREAM_PUSH=true ;;
     --upstream-only )
       shift; UPSTREAM_ONLY=true ;;
     -*)
@@ -320,11 +324,14 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
   else
     git clone --branch $CMSSW_BRANCH --no-checkout                                  --origin official-cmssw $OFFICIAL_CMSSW_REPO $CMSSW_BASE/src >&${verbose} 2>&1
   fi
-  git fetch official-cmssw --tags 2>&${verbose}
 
-  # create a new branch, pointing to the commit corresponding to $CMSSW_TAG, and switch to it
-  git branch from-$CMSSW_TAG $CMSSW_TAG
-  git symbolic-ref HEAD refs/heads/from-$CMSSW_TAG
+  if ! $UPSTREAM_PUSH; then
+    # disable pushing to the official upstream repository
+    git remote set-url --push official-cmssw disabled
+  fi
+
+  # update all branches and tags from the upstream repository
+  git fetch official-cmssw --tags 2>&${verbose}
 
   # setup sparse checkout
   git config core.sparsecheckout true
@@ -334,6 +341,13 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
     echo "${LEADING_SLASH}.clang-format"
   } > $CMSSW_BASE/src/.git/info/sparse-checkout
   git read-tree -mu HEAD
+
+  # create a new branch, pointing to the commit corresponding to $CMSSW_TAG, and switch to it
+  git branch from-$CMSSW_TAG $CMSSW_TAG
+  git symbolic-ref HEAD refs/heads/from-$CMSSW_TAG
+else
+  # update all branches and tags from the upstream repository
+  git fetch official-cmssw --tags 2>&${verbose}
 fi
 
 # setup the user's repository, if it doesn't exist already


### PR DESCRIPTION
  * Disabling pushing to the official-cmssw remote repository by default; use the new `-w` / `--enable-push` option to avoid this.

  * Set up the sparse checkout before switching branch; this leaves the repository in a working state even if the branch is not found.

  * If `git-cms-init` is rerun, update the official-cmssw remote.