### PR TITLE
Update git-cms-init

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -333,10 +333,6 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
   # update all branches and tags from the upstream repository
   git fetch official-cmssw --tags 2>&${verbose}
 
-  # create a new branch, pointing to the commit corresponding to $CMSSW_TAG, and switch to it
-  git branch from-$CMSSW_TAG $CMSSW_TAG
-  git symbolic-ref HEAD refs/heads/from-$CMSSW_TAG
-
   # setup sparse checkout
   git config core.sparsecheckout true
   {
@@ -345,6 +341,9 @@ if [ ! -d "$CMSSW_BASE/src/.git" ]; then
     echo "${LEADING_SLASH}.clang-format"
   } > $CMSSW_BASE/src/.git/info/sparse-checkout
   git read-tree -mu HEAD
+
+  # create a new branch, pointing to the commit corresponding to $CMSSW_TAG, and switch to it
+  git checkout $CMSSW_TAG -b from-$CMSSW_TAG 2>&${verbose}
 else
   # update all branches and tags from the upstream repository
   git fetch official-cmssw --tags 2>&${verbose}


### PR DESCRIPTION
Better fix for the issue reported at https://github.com/cms-sw/cms-git-tools/pull/99#issuecomment-417442636, which does not break `git-cms-init` for non cms-sw master repositories and with the added advantage of using a standard git command instead of an ad-hoc sequence of "plumbing" git commands.