### PR TITLE
poison cmssw data files so that removed files are not picked up from release src directory

### DIFF
--- a/git-cms-checkdeps
+++ b/git-cms-checkdeps
@@ -269,15 +269,20 @@ sub poisonIncludes() {
     use File::Basename qw(dirname);
     my $poison="${topdir}/${poisondir}";
     if (-d $poison){rmtree($poison);}
+    my $poisondata = "$poison/.data";
+    mkpath($poisondata);
     if (scalar(@$deletedFiles)>0) {print ">> Creating dummy files under $poison directory.\n";}
     foreach my $file (@$deletedFiles) {
         my $f="${poison}/${file}";
         my $dir=dirname($f);
         if (!-d $dir){mkpath($dir);}
-        my $ref;
-        if(!open($ref,">${f}")){die "ERROR: Can not open file for writing: $f\n";}
-        print $ref "#error THIS FILE HAS BEEN REMOVED FROM THE PACKAGE.\n";
-        close($ref);
+        if ($file=~/\/data\//o){symlink("$poisondata","$f");}
+        else{
+          my $ref;
+          if(!open($ref,">${f}")){die "ERROR: Can not open file for writing: $f\n";}
+          print $ref "#error THIS FILE HAS BEEN REMOVED FROM THE PACKAGE.\n";
+          close($ref);
+        }
         print "   $file\n";
     }
 }


### PR DESCRIPTION
This (along with the change in cmssw-config) should allow to poison cmssw data files. Currently if we delete a data file from a src/package/data area then in cmssw dev area (e.g. for PR tests) then removed data files is picked up from release/src directory.