### PR TITLE
Get default protocol from git config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-doc: docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1 docs/man/man1/git-cms-checkout-topic.1 docs/man/man1/git-cms-rebase-topic.1 docs/man/man1/git-cms-rmpkg.1
+doc: docs/man/man1/git-cms-init.1 docs/man/man1/git-cms-addpkg.1 docs/man/man1/git-cms-checkdeps.1 docs/man/man1/git-cms-merge-topic.1 docs/man/man1/git-cms-cvs-history.1 docs/man/man1/git-cms-showtags.1 docs/man/man1/git-cms-checkout-topic.1 docs/man/man1/git-cms-rebase-topic.1 docs/man/man1/git-cms-rmpkg.1
 
 docs/man/man1/%.1: docs/man/%.1.in
 	mkdir -p $(@D)

--- a/docs/man/git-cms-init.1.in
+++ b/docs/man/git-cms-init.1.in
@@ -1,0 +1,87 @@
+.TH GIT_CMS_INIT 1 LOCAL
+
+.SH NAME
+
+git-cms-init - CMSSW helper to initialize git repository with remotes in working area.
+
+.SH SYNOPSIS
+
+.B git cms-init [options] [release] 
+
+.SH DESCRIPTION
+
+This command is equivalent to 'git init' or 'git clone', but
+customized for the CMSSW use case.
+It initializes the git repository in the src/ folder of the CMSSW working
+area, with remotes configured: official-cmssw (upstream) and my-cmssw
+(origin, your personal fork).
+By default, the current release specified by the environment variable
+$CMSSW_BASE is used. An alternative release can be specified as the last argument.
+This command may be called by other commands such as cms-addpkg.
+
+To use a specified protocol (https, ssh, or mixed (default))
+always rather than specifying the flag each time, the git config can be used:
+
+git config --global cms.protocol ssh
+
+.SH OPTIONS
+
+.TP 5
+
+-d, --debug
+
+enable debug output
+
+.TP 5
+
+--check
+
+run additional checks on the status of the user repository
+
+.TP 5
+
+--https
+
+use https, rather than ssh to access your personal repository
+
+.TP 5
+
+--ssh
+
+use ssh, rather than https to access the official repository
+
+.TP 5
+
+--upstream-only
+
+configure only the official upstream repository, not the user repository
+
+.TP 5
+
+-w, --enable-push
+
+enable pushing to the official upstream repository
+
+.TP 5
+
+-x, --extra NAME
+
+configure an additional repository at https://github.com/NAME/cmssw with pushing disabled
+
+.TP 5
+
+-X, --extra-push NAME
+
+configure an additional repository at https://github.com/NAME/cmssw with pushing enabled
+
+.TP 5  
+
+-q, --quiet, -z
+
+do not print out progress
+
+.TP 5
+
+-y, --yes
+
+assume yes to all questions

--- a/git-cms-init
+++ b/git-cms-init
@@ -28,10 +28,17 @@ usage () {
   exit $1
 }
 
+# get default protocol from git config
+PROTOCOL=$(git config --get cms.protocol)
+HAS_PROTOCOL=$?
+# fallback to default
+if [ "$HAS_PROTOCOL" -ne 0 ]; then
+  PROTOCOL=mixed
+fi
+
 # configuration
 CHECK=
 CUSTOM_REMOTE=false
-PROTOCOL=mixed
 DEBUG=false
 VERBOSE=true
 UPSTREAM_ONLY=false

--- a/git-cms-init
+++ b/git-cms-init
@@ -34,6 +34,9 @@ HAS_PROTOCOL=$?
 # fallback to default
 if [ "$HAS_PROTOCOL" -ne 0 ]; then
   PROTOCOL=mixed
+elif [ "$PROTOCOL" != "https" ] && [ "$PROTOCOL" != "ssh" ] && [ "$PROTOCOL" != "mixed" ]; then
+  $ECHO "Unsupported value $PROTOCOL in cms.protocol (choose https, ssh, mixed)"
+  exit 1
 fi
 
 # configuration

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -48,6 +48,9 @@ HAS_PROTOCOL=$?
 # fallback to default (ignore "mixed")
 if [ "$HAS_PROTOCOL" -ne 0 ] || [ "$PROTOCOL" = "mixed" ]; then
   PROTOCOL=https
+elif [ "$PROTOCOL" != "https" ] && [ "$PROTOCOL" != "ssh" ] && [ "$PROTOCOL" != "mixed" ]; then
+  $ECHO "Unsupported value $PROTOCOL in cms.protocol (choose https, ssh, mixed)"
+  exit 1
 fi
 
 DEBUG=0

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -42,10 +42,17 @@ usage() {
 RED='\033[31m'
 NORMAL='\033[0m'
 
+# get default protocol from git config
+PROTOCOL=$(git config --get cms.protocol)
+HAS_PROTOCOL=$?
+# fallback to default (ignore "mixed")
+if [ "$HAS_PROTOCOL" -ne 0 ] || [ "$PROTOCOL" = "mixed" ]; then
+  PROTOCOL=https
+fi
+
 DEBUG=0
 VERBOSE=1
 INITOPTIONS=""                      # options passed to git cms-init
-PROTOCOL=https
 BACKUP=true
 BACKUP_NAME=_backup
 

--- a/git-cms-remote
+++ b/git-cms-remote
@@ -6,7 +6,7 @@ usage: git cms-remote add [--ssh|--https] [-w|--enable-push] USER
 
 Description:
   Adds a remote repository called USER pointing to https://github.com/USER/cmssw.git .
-  By default only fethcing from this remote is enabled, using the HTTPS protocol.
+  By default only fetching from this remote is enabled, using the HTTPS protocol.
   The default behaviour is to immediately fetch the new remote repository; this can be
   disabled with the '--no-fetch' option.
   Pushing can be enabled with the '-w' or '--enable-push' option; the default is 
@@ -25,7 +25,14 @@ Options:
   exit $1
 }
 
-PROTOCOL=mixed
+# get default protocol from git config
+PROTOCOL=$(git config --get cms.protocol)
+HAS_PROTOCOL=$?
+# fallback to default
+if [ "$HAS_PROTOCOL" -ne 0 ]; then
+  PROTOCOL=mixed
+fi
+
 READONLY=true
 FETCH=true
 COMMAND=

--- a/git-cms-remote
+++ b/git-cms-remote
@@ -31,6 +31,9 @@ HAS_PROTOCOL=$?
 # fallback to default
 if [ "$HAS_PROTOCOL" -ne 0 ]; then
   PROTOCOL=mixed
+elif [ "$PROTOCOL" != "https" ] && [ "$PROTOCOL" != "ssh" ] && [ "$PROTOCOL" != "mixed" ]; then
+  $ECHO "Unsupported value $PROTOCOL in cms.protocol (choose https, ssh, mixed)"
+  exit 1
 fi
 
 READONLY=true


### PR DESCRIPTION
I have noticed that fetching cmssw from GitHub over https is hanging with increasing frequency.

Rather than remember to use the `--ssh` flag every time, I have updated all the relevant commands to take the default access protocol from the user's global `.gitconfig`, if available. (If unavailable, the old default is used.)

I have specified the protocol selection should go in a new "cms" section of the `.gitconfig`, to avoid conflicts with any other settings.

I also noticed there was no man page for `git-cms-init`, so I added one, with a note about the `.gitconfig` protocol setting.