### PR TITLE
use current branch as default new_base for rebase

### DIFF
--- a/docs/man/git-cms-rebase-topic.1.in
+++ b/docs/man/git-cms-rebase-topic.1.in
@@ -62,7 +62,7 @@ Specify old base for merge-base or rebase (not used by default).
 
 -n, --new-base
 
-Specify new base for merge-base or rebase (default = $CMSSW_VERSION).
+Specify new base for merge-base or rebase (default = current branch).
 
 .TP 5
 

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -30,7 +30,7 @@ usage() {
   $ECHO "-o, --old-base       \tspecify old base for merge-base or rebase (not used by default)"
   # only for rebase-topic
   if [ "$COMMAND_NAME" = "cms-rebase-topic" ]; then
-    $ECHO "-n, --new-base       \tspecify new base for rebase (default = "'$CMSSW_VERSION'")"
+    $ECHO "-n, --new-base       \tspecify new base for rebase (default = current branch)"
   fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
   $ECHO "-A, --all-deps     \tperform checkdeps for all dependencies (header, python, BuildFile)"
@@ -198,11 +198,11 @@ if [ -z "$CMSSW_BASE" ]; then
   echo "CMSSW environment not setup, please run 'cmsenv' before 'git $COMMAND_NAME'."
   exit 1
 fi
-if [ -z "$NEW_BASE" ]; then
-  NEW_BASE=$CMSSW_VERSION
-fi
 if ! [ -d $CMSSW_BASE/src/.git ]; then
   git cms-init $INITOPTIONS
+fi
+if [ -z "$NEW_BASE" ]; then
+  NEW_BASE=$(git rev-parse --abbrev-ref HEAD)
 fi
 
 cd $CMSSW_BASE/src


### PR DESCRIPTION
It was brought to my attention a while ago that `git-cms-rebase-topic` behaves unlike its sibling commands. If `git-cms-merge-topic` is used twice with branches A and B, the result is base+A+B. If `git-cms-rebase-topic` is used twice, it creates two separate rebased branches A' = base+A and B' = base+B. This is not obvious or intuitive for most naive use of the command.

Therefore, I have updated the command to use the current branch as the default new base for the rebase. This means that using it twice will result in base+A+B (A rebased onto base, B rebased onto base+A).

The old behavior, if desired, can be restored with the argument `--new-base $CMSSW_VERSION`. (I suspect most people were not relying on this old behavior, so changing the default should be fine.)