### PR TITLE
use no-renames with git diff to get package names with renamed files

### DIFF
--- a/git-cms-sparse-checkout
+++ b/git-cms-sparse-checkout
@@ -94,7 +94,7 @@ git config core.sparsecheckout true
 INFO_DIR=`git rev-parse --show-toplevel`/.git/info/
 touch $INFO_DIR/sparse-checkout
 cp -f $INFO_DIR/sparse-checkout $INFO_DIR/sparse-checkout-new
-for x in `git diff $REGEX_OPT $REGEX $REF1..$REF2 --name-only | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
+for x in `git diff $REGEX_OPT $REGEX $REF1..$REF2 --name-only  --no-renames | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do
   echo "$x" | sed -e "s|[/]*$|/|;s|^/*|${LEADING_SLASH}|" >> $INFO_DIR/sparse-checkout-new
 done
 for x in `git diff $REF1..$REF2 | grep '^old mode' -C 1 | grep '^diff --git' | sed -e 's|.* ||;s|b/||' | grep -v ".gitconfig" | cut -f1,2 -d/ | sort -u`; do


### PR DESCRIPTION
We have noticed  ( https://github.com/cms-sw/cmssw/pull/28881  https://github.com/cms-sw/cmssw/pull/28847 ) that git-cms-sparse-checkout does not checkout packages where we only have renamed files. Problem is that `git diff --name-only`  does not show files which were renamed, passing `--no-renames` option should fix this issue

FYI, @silviodonato , @kpedro88 , @makortel , @fabiocos

[a]

```
diff -u <(git diff CMSSW_11_1_X_2020-02-04-2300..CMSSW_11_1_X_2020-02-05-2300 --name-only) <(git diff CMSSW_11_1_X_2020-02-04-2300..CMSSW_11_1_X_2020-02-05-2300 --name-only --no-renames)
--- /dev/fd/63  2020-02-08 14:12:52.960402077 +0100
+++ /dev/fd/62  2020-02-08 14:12:52.960402077 +0100
@@ -1,3 +1,5 @@
+Configuration/Eras/python/Modifier_dd4hep_cff.py
+Configuration/Geometry/python/DD4hep_GeometrySim_cff.py
 Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
 Configuration/Geometry/python/GeometryDD4hepExtended2021_cff.py
 Configuration/ProcessModifiers/python/dd4hep_cff.py
```