### PR TITLE
run checkdeps with -A opt for merge/checkout topic commands

### DIFF
--- a/docs/man/man1/git-cms-checkout-topic.1
+++ b/docs/man/man1/git-cms-checkout-topic.1
@@ -40,13 +40,6 @@ Specify old base for merge-base or rebase (not used by default).
 
 Do not perform checkdeps at the end of the checkout.
 
-.TP 5
-
--A, --all-deps
-
-Perform checkdeps for all dependencies (header, python, BuildFile).
-(Default: header, python.)
-
 .SH DESCRIPTION
 
 This is an alternate mode for git-cms-merge-topic.

--- a/docs/man/man1/git-cms-merge-topic.1
+++ b/docs/man/man1/git-cms-merge-topic.1
@@ -70,13 +70,6 @@ Specify old base for merge-base or rebase (not used by default).
 
 Do not perform checkdeps at the end of the checkout.
 
-.TP 5
-
--A, --all-deps
-
-Perform checkdeps for all dependencies (header, python, BuildFile).
-(Default: header, python.)
-
 .SH DESCRIPTION
 
 This is the git equivalent of the old CVS cmstc tagset <tagset-id> command.

--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -33,7 +33,6 @@ usage() {
     $ECHO "-n, --new-base       \tspecify new base for rebase (default = current branch)"
   fi
   $ECHO "-u, --unsafe       \tdo not perform checkdeps at the end"
-  $ECHO "-A, --all-deps     \tperform checkdeps for all dependencies (header, python, BuildFile)"
   $ECHO "                   \t(default: header, python)"
   exit $CODE
 }
@@ -70,7 +69,6 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     -A|--all-deps)
-      ALLCHECKDEPS=-A
       shift
       ;;
     -d|--debug)
@@ -275,7 +273,7 @@ fi
 git branch -D $TEMP_BRANCH >&${debug} || true
 # Do checkdeps unless not specified.
 if [ ! "X$UNSAFE" = Xtrue ]; then
-  git cms-checkdeps -a $ALLCHECKDEPS
+  git cms-checkdeps -a -A
 fi
 # check if topic branch is behind release branch
 if [ "$COMMAND_NAME" = "cms-checkout-topic" ]; then


### PR DESCRIPTION
I kept the `-A|--all-deps` option in the git-cms-merge-topic tool so that it does not break any existing script which is explicitly using it