### PR TITLE
Do not force create CMSSW_BASE/src

### DIFF
--- a/git-cms-init
+++ b/git-cms-init
@@ -328,7 +328,7 @@ if [ -e $CMSSW_GIT_REFERENCE/create-`whoami` ]; then
   (cd $CMSSW_GIT_REFERENCE ; git remote update origin >&${verbose} 2>&1)
 fi
 
-[ -d $CMSSW_BASE/src ] || mkdir $CMSSW_BASE/src
+[ -e $CMSSW_BASE/src ] || mkdir $CMSSW_BASE/src
 cd $CMSSW_BASE/src
 
 # setup the upstream "official" repository


### PR DESCRIPTION
`git cms-init` is always creating `$CMSSW_BASE/src`. This means if one has deleted the CMSSW_BASE after setting the env and run `git cms-init` then it will create `$CMSSW_BASE/src` again. This PR proposes to create `$CMSSW_BASE/src` if not exists and only create `src` if `$CMSSW_BASE` already exists.