### PR TITLE
Update git-cms-checkdeps

### DIFF
--- a/git-cms-checkdeps
+++ b/git-cms-checkdeps
@@ -233,7 +233,7 @@ for file in changedFiles:
         try:
             recompile = "%s/%s" % (sp[0], sp[1])
         except IndexError:
-            pass
+            recompile = ""
         if not list(filter(lambda x: recompile==x, packages)):
             scope = "header"
             if re.search(r'\.py$', file):


### PR DESCRIPTION
Avoid the following error:
```
Traceback (most recent call last):
File "/data/cmsbld/jenkins/workspace/build-any-ib/w/common/git-cms-checkdeps", line 237, in <module>
if not list(filter(lambda x: recompile==x, packages)):
File "/data/cmsbld/jenkins/workspace/build-any-ib/w/common/git-cms-checkdeps", line 237, in <lambda>
if not list(filter(lambda x: recompile==x, packages)):
NameError: name 'recompile' is not defined
```