### PR TITLE
Minor updates

### DIFF
--- a/git-cms-cherry-pick-pr
+++ b/git-cms-cherry-pick-pr
@@ -2,10 +2,10 @@
 
 function usage() {
   cat <<@EOF
-Usage: git cms-show-pr <pull request> [<branch>]
+Usage: git cms-cherry-pick-pr <pull request> [<branch>]
 
 Description:
-  Cherry pick the commits that are part of a pull request that has been opened or merged 
+  Cherry pick the commits that compose pull request that has been opened or merged
   in the master branch, or in <branch> if it is specified.
 @EOF
   exit $1

--- a/git-cms-fetch-pr
+++ b/git-cms-fetch-pr
@@ -21,7 +21,7 @@ while [ "$#" != 0 ]; do
       usage 1
       ;;
     *)
-      if [ "$COMMAND" == "" ]; then
+      if [ "$PULL" == "" ]; then
         PULL=$1
       elif [ "$BRANCH" == "" ]; then
         BRANCH=$1

--- a/git-cms-show-pr
+++ b/git-cms-show-pr
@@ -34,4 +34,4 @@ git fetch -q $REMOTE pull/$PULL/head
 BRANCH_POINT=$(diff -u <(git rev-list --first-parent FETCH_HEAD) <(git rev-list --first-parent $REMOTE/$BRANCH) | sed -ne 's/^ //p' | head -n1 -)
 
 # show the commits in the pull request
-git log --oneline FETCH_HEAD...$BRANCH_POINT
+git log --no-decorate --oneline --reverse --topo-order FETCH_HEAD...$BRANCH_POINT


### PR DESCRIPTION
Update the usage and description of `git cms-cherry-pick-pr`.
Do not show tags and branches in `git cms-show-pr`.