### PR TITLE
fix newline in git log format

### DIFF
--- a/git-cms-merge-topic
+++ b/git-cms-merge-topic
@@ -330,7 +330,7 @@ if [ "$NOMERGE" = "true" ]; then
     #   then selects lines matching: any number of spaces + "Co-authored-by: " (which is then removed)
     #   i = case-insensitive, p = print
     # finally, sort removes duplicates, and grep removes the current user (who will already be the author of the squash commit)
-    readarray -t COAUTHORS < <(git log $MERGE_BASE_BRANCH..$FULL_BRANCH --format="Co-Authored-by: %an <%ae>\n%B" | sed -n 's/^ *Co-authored-by: //ip' | sort -u | grep -v "$SQUASH_AUTHOR")
+    readarray -t COAUTHORS < <(git log $MERGE_BASE_BRANCH..$FULL_BRANCH --format="Co-Authored-by: %an <%ae>%n%B" | sed -n 's/^ *Co-authored-by: //ip' | sort -u | grep -v "$SQUASH_AUTHOR")
     # by default, automatically populate commit message
     git reset --hard $MERGE_BASE
     git merge --squash "HEAD@{1}"


### PR DESCRIPTION
Addresses issue reported at https://github.com/cms-sw/cms-git-tools/pull/125#issuecomment-1912020011 / https://github.com/cms-sw/cmssw/pull/43592#issuecomment-1911840635. Proof that it works as expected now: https://github.com/kpedro88/cmssw/commit/aac6c7dd3157573fe88ae2d18d871078fef39f66